### PR TITLE
Corrected the orientation of beam phase grating

### DIFF
--- a/samples/compute/beamssample.py
+++ b/samples/compute/beamssample.py
@@ -4,7 +4,6 @@ path_root = Path(__file__).parents[2]
 sys.path.append(str(path_root))
 from src.compute.beams import Beam
 from src.compute.calibration import Calibration
-from src.compute.SLMBogus import SLM 
 from matplotlib import pyplot as plt
 from scipy.constants import pi
 from numpy.polynomial import Polynomial as P
@@ -14,9 +13,9 @@ import numpy as np
 A snippet of code demonstrating how to use some of the features in the Beams class
 '''
 
-bm=Beam(1200,1920)
+bm=Beam(1920,1200)
 bm.set_pixelToWavelength(P(1e-9*np.array([500,1/6])))# Sets bogus polynomial for pix to wave conversionpix2wave
-bm.set_compressionCarrierWave(532e-9)
+bm.set_compressionCarrierWave(630e-9)
 print('Wavelength at pixel 111:  %.3e m'%bm.get_spectrumAtPixel(111))
 print('Frequency at pixel 111:  %.3e Hz'%bm.get_spectrumAtPixel(111,unit='frequency'))
 print('Angular frequency at pixel 111:  %.3e rad Hz'%bm.get_spectrumAtPixel(111,unit='ang_frequency'))
@@ -24,7 +23,7 @@ print('Energy at pixel 111:  %.3e eV'%bm.get_spectrumAtPixel(111,unit='energy'))
 print('Compression carrier wavelenght is %.2e nm'%bm.get_compressionCarrier(unit='wavelength'))
 print('Compression carrier angular frequency is %.2e rad.Hz'%bm.get_compressionCarrier(unit='ang_frequency'))
 bm.set_optimalPhase(P([0,0,1000,500]))
-bm.set_currentPhase(P([0,10,-1000,-500]),mode='relative')
+bm.set_currentPhase(P([0,10,-500,-500]),mode='relative')
 bm.set_beamVerticalDelimiters([100,250])
 
 print('Optimal phase is now:')
@@ -41,7 +40,7 @@ print(bm.get_currentPhase(mode='absolute'))
 amplitude=1
 bm.set_gratingAmplitude(amplitude)
 print('Current amplitude (units of 2*pi) is %.2f'%bm.get_gratingAmplitude())
-period=10
+period=100
 bm.set_gratingPeriod(period)
 print('Current grating period is %d pixels'%bm.get_gratingPeriod())
 plt.figure()

--- a/samples/drivers/exemple_image_generation.py
+++ b/samples/drivers/exemple_image_generation.py
@@ -15,12 +15,12 @@ import numpy as np
 Exemple of image generation for the SLM. The idea is to create the image outside of SLMdemo to only import it in the code
 '''
 def beam_image_gen():
-    bm=Beam(1200,1920)
+    bm=Beam(1920,1200)
     bm.set_pixelToWavelength(P(1e-9*np.array([500,1/6])))# Sets bogus polynomial for pix to wave conversionpix2wave
-    bm.set_compressionCarrierWave(532e-9)
+    bm.set_compressionCarrierWave(600e-9)
         
     bm.set_optimalPhase(P([0,0,1000,500]))
-    bm.set_currentPhase(P([0,100,500]),mode='relative')
+    bm.set_currentPhase(P([0,-100,-400]),mode='relative')
     bm.set_beamVerticalDelimiters([0,1200])
 
     amplitude=1

--- a/src/compute/beams.py
+++ b/src/compute/beams.py
@@ -43,7 +43,7 @@ class Beam:
                 - horizontalDelimiters (nd.array, Default None) Indices of the two horizontal limiting edges of the beam. Default uses internal delimiters
                 - verticalDelimiters (nd.array, Default None) Indices of the two vertical limiting edges of the beam. Default uses internal delimiters
         '''
-        self.mask=np.zeros((self.SLMWidth,self.SLMHeight))
+        self.mask=np.zeros((self.SLMHeight,self.SLMWidth))
         if horizontalDelimiters is None:
             horizontalDelimiters=self.get_beamHorizontalDelimiters()
         if verticalDelimiters is None:
@@ -306,15 +306,14 @@ class Beam:
             output:
                 - 2d.array: A 2D phase array corresponding to the current phase profile in rad
         '''
+        phaseGratingImage=np.zeros((self.SLMHeight,self.SLMWidth))
         if self.phaseGratingPeriod is None:
-            
-            return np.zeros((self.SLMWidth,self.SLMHeight))
-        phaseGratingImage=[]
+            return phaseGratingImage
         numberVerticalPixels=self.SLMHeight
+        print('Number of vertical pixels %.0f'%numberVerticalPixels)
         phaseProfile=self.get_sampledCurrentPhase()
-        for phase in phaseProfile:
-            row=self.generate_1Dgrating(self.get_gratingAmplitude(),self.get_gratingPeriod(),phase,num=numberVerticalPixels)
-            phaseGratingImage.append(row)
+        for i,phase in enumerate(phaseProfile):
+            phaseGratingImage[:,i]=self.generate_1Dgrating(self.get_gratingAmplitude(),self.get_gratingPeriod(),phase,num=numberVerticalPixels)
         phaseGratingImage=np.array(phaseGratingImage)
         if self.maskOn:
             phaseGratingImage=phaseGratingImage*self.mask


### PR DESCRIPTION
Fixed the orientation of the phase grating to be correctly aligned with the SLM.

To check that the code works:

1. run `.\samples\compute\beamsamples.py` and get the following image ![image](https://github.com/user-attachments/assets/d04e4e10-706c-4021-964e-2d177ba3dbcc)
2. run `.\samples\drivers\exemple_image_generation.py` and get  ![image](https://github.com/user-attachments/assets/c5cda526-0678-4c42-ae26-de9afa083cbb)
3. - run `main.py` and get that same image on the secondary monitor. 

I couldn't run test 3 on my machine due to [issues with the SLM driver](https://github.com/SilvaScience/colberto/issues/42). If you do not have this issue, could you please check this point as well on your lab computers?