### PR TITLE
The beam explorer and SLM windows are all closed when the main window…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import numpy as np
 from numpy.polynomial import Polynomial as P
 from PyQt5 import QtCore, QtWidgets, uic
+from PyQt5.QtWidgets import QApplication
 import pyqtgraph as pg
 from functools import partial
 import pyqtgraph as pg
@@ -675,7 +676,11 @@ class MainInterface(QtWidgets.QMainWindow):
         """
         self.beam_explorer= BeamExplorer(self.DataHandling.get_beams())
         self.beam_explorer.show()
-    
+    def closeEvent(self,event):
+        '''
+            Closes all windows when the main window is closed.
+        '''
+        QApplication.closeAllWindows()
 
 class UpdateWorker(QtCore.QThread):
 
@@ -698,7 +703,6 @@ class UpdateWorker(QtCore.QThread):
                         self.updated_param[param] = self.devices[devices].parameter_dict[param]
                 self.new_parameter.emit(self.updated_param)
             time.sleep(self.update_interval)
-
 
 app = QtWidgets.QApplication(sys.argv)
 window = MainInterface()


### PR DESCRIPTION
… is closed

I added a few lines that close all windows when the main one is closed.

Step to check that it works:
* Launch the application
* An empty beam explorer window will show up as well as the SLM display
* Press the X in the upper right corner of the main window. It should close all other windows.