### PR TITLE
Integrating the Pixis Camera and the monochromator

### DIFF
--- a/manual/camera_spectrometer.md
+++ b/manual/camera_spectrometer.md
@@ -1,0 +1,5 @@
+# Camera and spectrometer
+
+Colbert can be used with two cameras (Stresing and Pixis) plugged to one spoectrometer. Everything is managed in the intruments.py where you can add or removed devices. The spectrometer is the main device where the cameras could be attached, meaning that all camera parameters are child of the parent spectrometer. Those parameters are all saved and managed through Data Handling. 
+
+On the main panel, on the top right, you can find a sliding menu where there is a list of the connected cameras. Selecting another camera reset completely Data Handling beacause the number of parameter is changing between cameras and also the length of the sensor may be different. For those reasons, it is easier to reset. All the other calibrations that were not associated with the camera will be loaded back. However, the connection between the beam explorer and Data Handling seems to be lost. 

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -91,8 +91,12 @@ class DataHandling(QtCore.QThread):
         hardware parameter is added to the deque"""
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
+
         for idx, param in enumerate(self.parameter):
             self.parameter_queue[param].append(parameter[idx])
+
+        # for param, value in zip(self.parameter_queue, parameter):
+        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -308,7 +312,10 @@ class DataHandling(QtCore.QThread):
         Parameters:
             new_length (int): The new number of pixels in the spectrum.
         """
-        self.speclength = new_length
+        if isinstance(new_length, tuple):
+            self.speclength = new_length[1]  # or [0], whichever is intended
+        else:
+            self.speclength = new_length
 
         # Reset spectrum buffer
         self.spec = np.zeros((self.speclength, 0))  # zero columns, rows = new_length
@@ -331,6 +338,47 @@ class DataHandling(QtCore.QThread):
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")
+
+    def close(self):
+        """Safely stop Qt thread + worker before re-instantiating DataHandling."""
+
+        # 1. Stop worker thread safely (if it has a stop flag)
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.terminate = True  # your custom flag (optional)
+        except:
+            pass
+
+        # 2. Disconnect signals (VERY important)
+        try:
+            if hasattr(self, "bufferSaveSignal"):
+                self.bufferSaveSignal.disconnect()
+        except:
+            pass
+
+        # 3. Quit Qt thread event loop
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.quit()
+                self.thread.wait()   # blocks until fully stopped
+        except:
+            pass
+
+        # 4. Delete worker safely
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.deleteLater()
+                self.BufferWorker = None
+        except:
+            pass
+
+        # 5. Delete thread safely
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.deleteLater()
+                self.thread = None
+        except:
+            pass
 
 
 class BufferWorker(QtCore.QObject):

--- a/src/GUI/main_GUI.ui
+++ b/src/GUI/main_GUI.ui
@@ -349,7 +349,7 @@ p, li { white-space: pre-wrap; }
       <item>
        <widget class="QTabWidget" name="tabWidget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>6</number>
         </property>
         <widget class="QWidget" name="spectro_tab">
          <attribute name="title">
@@ -2714,6 +2714,11 @@ p, li { white-space: pre-wrap; }
            <item>
             <property name="text">
              <string>2Q</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>LO scan</string>
             </property>
            </item>
           </widget>

--- a/src/compute/beams.py
+++ b/src/compute/beams.py
@@ -481,10 +481,6 @@ class Beam:
         elif TaylorPrefactorFlag == 'remove':
             coef = [c / f for c, f in zip(coef, TaylorFactor)]
 
-        # Add minus sign to the group delay (linear term)
-        if len(coef) > 1:
-            coef[1] *= -1
-
         return P(coef)
     
     @staticmethod

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -44,27 +44,33 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
-    # Shamrock grating parameters
-    grating_params={
-        'focal_length_mm':163,
-        'delta':np.float64(-0.20488367116307532),
-        'gamma':np.float64(2.021864300924973),
-        'n0':np.float64(511.0), # Central pixel
-        'offset_adjust':0,
-        'd_grating':np.float64(6666.666666666667),
-        'x_pixel':26000.0,
-        'curvature':np.float64(3.1224154313329654e-06),
-    }
-    # SpectraPro 2300i grating parameters
-    grating_params = {
+    grating_params_stresing={
         'focal_length_mm':300,
-        'delta':np.float64(0),
-        'gamma':np.float64(0),
-        'n0':np.float64(511.0), # Central pixel
+        'f':np.float64(305381928.6149399),
+        'delta':np.float64(0.11432112488955509),
+        'gamma':np.float64(0.5337955112241486),
+        'n0':np.float64(539.4), # Central pixel
         'offset_adjust':0,
-        'd_grating':None,
-        'x_pixel':None,
-        'curvature':np.float64(0),
+        'd_grating':833.3333333333334,
+        'x_pixel':24000.0,
+        'curvature':np.float64(5.736575254871788e-07),
+    }
+    f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
+    grating_params_pixis = {
+        'focal_length_mm':300,
+        'f':np.float64(300000000.0),
+        'delta':np.float64(0.06),
+        'gamma':np.float64(0.5),
+        'n0':np.float64(516.6), # Central pixel
+        'offset_adjust':0,
+        'd_grating':833.3333333333334,
+        'x_pixel':26000,
+        'curvature':np.float64(0.0),
+    }
+
+    grating_params = {
+        'Stresing': grating_params_stresing,
+        'Pixis': grating_params_pixis
     }
     Monochrom = SpectraPro2300i(grating_params) 
 
@@ -77,7 +83,7 @@ def load_instruments():
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
-        'calibrated': False,
+        'calibrated': True,
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
@@ -85,7 +91,7 @@ def load_instruments():
     pixis_params = {
         'pixel_size_mm':26e-3,
         'num_pixels':1024,
-        'calibrated':False,
+        'calibrated':True,
         'calibrationThirdOrder':0,
         'calibrationSlope':0,
         'calibrationOffset':0

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -9,6 +9,8 @@ from drivers.SLM import Slm
 from drivers.SLMDemo import SLMDemo
 from drivers.Stresing import StresingCamera
 from drivers.Shamrock import Shamrock 
+from drivers.Pixis import Pixis
+from drivers.SpectraPro2300i import SpectraPro2300i
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +44,9 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
+    # Shamrock grating parameters
     grating_params={
         'focal_length_mm':163,
-        'f':np.float64(330605663.74965495),
         'delta':np.float64(-0.20488367116307532),
         'gamma':np.float64(2.021864300924973),
         'n0':np.float64(511.0), # Central pixel
@@ -53,11 +55,25 @@ def load_instruments():
         'x_pixel':26000.0,
         'curvature':np.float64(3.1224154313329654e-06),
     }
-    Monochrom = Shamrock(grating_params) 
+    # SpectraPro 2300i grating parameters
+    grating_params = {
+        'focal_length_mm':300,
+        'delta':np.float64(0),
+        'gamma':np.float64(0),
+        'n0':np.float64(511.0), # Central pixel
+        'offset_adjust':0,
+        'd_grating':None,
+        'x_pixel':None,
+        'curvature':np.float64(0),
+    }
+    Monochrom = SpectraPro2300i(grating_params) 
+
+    
+    
     devices['Monochrom'] = Monochrom 
     logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
 
-    # initialize StresingDemo
+    # initialize Cameras
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
@@ -65,6 +81,14 @@ def load_instruments():
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
+    }
+    pixis_params = {
+        'pixel_size_mm':26e-3,
+        'num_pixels':1024,
+        'calibrated':False,
+        'calibrationThirdOrder':0,
+        'calibrationSlope':0,
+        'calibrationOffset':0
     }
 
     spectrometers = {}
@@ -76,6 +100,14 @@ def load_instruments():
         logger.info('%s Stresing connected' % datetime.datetime.now())
     except Exception as e:
         logger.warning(f'Stresing failed: {e}')
+
+    try:
+        camera = Pixis(pixis_params)
+        spectrometers['Pixis'] = camera
+        camera.attach_to_monochromator(Monochrom)
+        logger.info('%s Pixis connected' % datetime.datetime.now())
+    except Exception as e:
+        logger.warning(f'Pixis failed: {e}')
 
     try:
         from drivers.OceanSpectrometer import OceanSpectrometer

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -64,7 +64,7 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['unit'] = ' celsius'
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
-        self.parameter_display_dict['sensor_T']['read'] = True
+        self.parameter_display_dict['sensor_T']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -223,8 +223,9 @@ class Pixis(QtCore.QThread):
         spectrum = spectrum[0, :]
         return spectrum
 
-    def update_temperature(self,temperature):
+    def update_temperature(self, temperature):
         self.parameter_dict['sensor_T'] = temperature
+        self.parameter_display_dict['sensor_T']['val'] = temperature
 
 
 class CameraWorker(QtCore.QThread):

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -119,7 +119,8 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array()
+        self.calculate_wavelength_array()
+        return self.wavelengths
 
     def calculate_wavelength_array(self):
         """
@@ -136,32 +137,32 @@ class Pixis(QtCore.QThread):
             focal_length_mm = self.hardware_params['focal_length_mm']
             num_pixels = self.hardware_params['num_pixels']
         
-        calibrated = False
-        if calibrated:
-            pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 300  # specs of SP2150
-            num_pixels = 1024  # specs of PIXIS
+        if self.hardware_params['calibrated']:
 
-            #
+            pixel_size_mm = 26 / 1E3  # specs of PIXIS
+            focal_length_mm = 300  # specs of SP2300
+            num_pixels = 1024  # specs of PIXIS
 
             wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
             # calibration from notebook
-            f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
-
-
+            f=self.hardware_params['f']
+            delta=self.hardware_params['delta']
+            gamma=self.hardware_params['gamma']
+            n0=self.hardware_params['n0']
+            offset_adjust=self.hardware_params['offset_adjust']
+            d_grating=self.hardware_params['d_grating']
+            x_pixel=self.hardware_params['x_pixel']
+            curvature=self.hardware_params['curvature']
 
             n = px - (n0 + offset_adjust * wl_center)
-
-            # print('psi top', m_order* wl_center)
-            # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
 
             psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
             eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
-            wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+            self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
             focal_length_mm = 300  # specs of SP2150
@@ -177,9 +178,7 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-
-        return wavelengths
+            self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
     def attach_to_monochromator(self,monochromator):
         """
@@ -189,7 +188,7 @@ class Pixis(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Pixis'))
     
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -22,21 +22,21 @@ from PyQt5 import QtCore
 from collections import defaultdict
 from pylablib.devices import PrincetonInstruments
 import time
-import serial
 import re
 
 class Pixis(QtCore.QThread):
 
     name = 'Pixis'
     
-    def __init__(self):
+    def __init__(self, hardware_params):
         super(Pixis, self).__init__()
 
         #self.camera.start()
-        self.wavelength =  np.linspace(200,1000,1024) # get property from Worker
+        self.wavelength = np.linspace(200,1000,1024) # get property from Worker
         self.px0 = np.linspace(1,1024,1024)
-        self.spec_length = (252,1024) # get property from Worker
+        self.spec_length = 1024 #(252,1024) # get property from Worker
         self.image = np.zeros(self.spec_length)
+        self.hardware_params = hardware_params
 
         # Indicate shutter, required to discriminate between different detectors
         self.shutter = True
@@ -46,30 +46,6 @@ class Pixis(QtCore.QThread):
         self.int_time = 100
         self.binned_spec = np.zeros(self.spec_length)
         self.new_spectrum = False
-
-        # set up spectrograph
-        self.serial_busy = False
-        port = 'COM6'
-        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
-                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
-        # get startup values
-        self.grating = float(self.write_command('?GRATING')[0])
-        numbers = self.write_command('?GRATINGS')
-        self.num_gratings = int((len(numbers)-8)/2)
-        self.grating_densities = np.zeros(self.num_gratings)
-        self.grating_blazes = np.zeros(self.num_gratings)
-        for i in range(self.num_gratings):
-            self.grating_densities[i] = numbers[i*3 + 1]
-            self.grating_blazes[i] = numbers[i * 3 + 2]
-        self.center_wl = float(self.write_command('?NM')[0])
-        print(self.center_wl)
-        print(self.grating_densities)
-        print(self.grating_blazes)
-        print(self.grating)
-        print('SP2150 grating info: ', numbers)
-        print('SP2150 grating densities: ',self.grating_densities)
-        print('SP2150 grating blazes: ',self.grating_blazes)
-        print('SP2150 selected grating: ',self.grating)
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -89,14 +65,6 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
         self.parameter_display_dict['sensor_T']['read'] = True
-        self.parameter_display_dict['center_wl']['val'] = self.center_wl
-        self.parameter_display_dict['center_wl']['unit'] = ' nm'
-        self.parameter_display_dict['center_wl']['max'] = 2000
-        self.parameter_display_dict['center_wl']['read'] = False
-        self.parameter_display_dict['grating']['val'] = self.grating
-        self.parameter_display_dict['grating']['unit'] = ' grat'
-        self.parameter_display_dict['grating']['max'] = 3
-        self.parameter_display_dict['grating']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -108,6 +76,10 @@ class Pixis(QtCore.QThread):
         print(PrincetonInstruments.list_cameras())
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
+
+        # set the ROI so the camera is acting like a 1D array of 1024 pixels
+        roi = {"x": 0, "width": 1024, "x_binning": 1, "y": 0, "height": 1, "y_binning": 1}
+        self.camera.set_attribute_value("ROIs", [roi])
 
         # initialize camera
         self.worker = CameraWorker(self.camera,self.int_time)
@@ -134,16 +106,6 @@ class Pixis(QtCore.QThread):
         elif parameter == 'avg_scan':
             self.parameter_dict['avg_scan'] = value
             self.avg_scan = int(value)
-        elif parameter == 'center_wl':
-            cmd = f'{value:0.3f} GOTO'
-            self.write_command(cmd)
-            self.parameter_dict['center_wl'] = value
-            self.center_wl = value
-        elif parameter == 'grating':
-            cmd = f'{value:1.0f} GRATING'
-            self.write_command(cmd)
-            self.parameter_dict['grating'] = value
-            self.grating = value
 
 
     def update_spectrum(self, spec, int_time):
@@ -157,28 +119,32 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array(self.center_wl,self.grating_densities[int(self.grating-1)])
+        return self.calculate_wavelength_array()
 
-    def calculate_wavelength_array(self,center_wavelength_nm,grating_lines_per_mm):
+    def calculate_wavelength_array(self):
         """
         Calculate the wavelength array for a PIXIS camera on SP-2150 spectrograph.
 
         Parameters:
-            center_wavelength_nm: Central wavelength (nm)
-            grating_lines_per_mm: Groove density (lines/mm)
 
         Returns:
             wavelengths: 1D numpy array of wavelengths (nm)
         """
-        calibrated = True
+        if self.monochromator is not None:
+            self.center_wavelength,self.grating_lines_per_mm=self.monochromator.get_monochromator_parameters()
+            pixel_size_mm =self.hardware_params['pixel_size_mm'] 
+            focal_length_mm = self.hardware_params['focal_length_mm']
+            num_pixels = self.hardware_params['num_pixels']
+        
+        calibrated = False
         if calibrated:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             #
 
-            wl_center = center_wavelength_nm
+            wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
@@ -198,11 +164,11 @@ class Pixis(QtCore.QThread):
             wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             # Calculate linear dispersion (nm/mm)
-            dispersion = 1e6 / (focal_length_mm * grating_lines_per_mm)
+            dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
             # Center pixel
             center_pixel = num_pixels // 2
@@ -211,10 +177,20 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = center_wavelength_nm + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
+            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
         return wavelengths
 
+    def attach_to_monochromator(self,monochromator):
+        """
+            Attaches the camera to a monochromator, letting the camera interface know where to get the monochromator parameters from.
+            input:
+                - monochromator (Monochromator QThread): The interface to the monochromator
+        """
+        self.monochromator=monochromator
+        self.type='Spectrometer'
+        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+    
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """
         self.camera.start_acquisition()
@@ -229,6 +205,7 @@ class Pixis(QtCore.QThread):
         """ Gets the intensity. The example include the possibility of averaging several spectra and to
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
+        self.start_acquisition()
         if self.avg_scan == 1:
             while not self.new_spectrum:
                 time.sleep(0.01)
@@ -243,35 +220,12 @@ class Pixis(QtCore.QThread):
                 spectrum = spectrum + self.spectrum
                 self.new_spectrum = False
             spectrum = spectrum / self.avg_scan
+        self.stop_acquisition()
+        spectrum = spectrum[0, :]
         return spectrum
 
     def update_temperature(self,temperature):
         self.parameter_dict['sensor_T'] = temperature
-
-    def write_command(self, cmd):
-        """ Command to write to serial handles timeout by blocking serial commands
-        Args:
-            ser: serial object
-            cmd: write command as defined in PI API
-
-        Returns: read string with only digit content. For troubleshooting, consider printing
-        the entire answer string
-        """
-        cmd_bytes = cmd.encode('ASCII')
-        self.ser.write(cmd_bytes + b"\r")
-        out = bytearray()
-        char = b""
-        missed_char_count = 0
-        while char != b"k":
-            char = self.ser.read()
-            if char == b"":  # handles a timeout here
-                missed_char_count += 1
-                self.serial_busy = True
-                time.sleep(0.1)
-            out += char
-        self.serial_busy = False
-        return re.findall(r'\d+', out.decode().strip())
-
 
 
 class CameraWorker(QtCore.QThread):
@@ -288,7 +242,7 @@ class CameraWorker(QtCore.QThread):
 
         # definition of some parameters
         self.camera = camera
-        self.spec_length = (252,1024)
+        self.spec_length = 1024
         self.change_int_time = False
         self.spectrum = np.zeros(self.spec_length)
         self.int_time = int_time

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -110,7 +110,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
 
-    def get_hardware_parameters(self):
+    def get_hardware_parameters(self, name):
         """
             Returns the hardware parameters of the monochromator
             output:
@@ -125,7 +125,8 @@ class SpectraPro2300i(QtCore.QThread):
                     - curvature
 
         """
-        return self.hardware_params
+        return self.hardware_params[name]
+    
     def get_monochromator_parameters(self):
         """
             Returns the current parameters of the monochromator.
@@ -133,6 +134,4 @@ class SpectraPro2300i(QtCore.QThread):
                 - central_wavelength (np.float): the central wavelength in nm
                 - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
         """
-        return self.center_wl, self.grating_densities[int(self.grating)]
-
-
+        return self.center_wl, self.grating_densities[int(self.grating-1)]

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -1,0 +1,138 @@
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: KatieKoch, Felix Thouin
+"""
+
+import numpy as np
+from PyQt5 import QtCore
+from collections import defaultdict
+import time
+import serial
+import re
+
+class SpectraPro2300i(QtCore.QThread):
+    
+    name = 'SpectraPro2300i'
+    type = 'Monochromator'
+    
+    def __init__(self,hardware_params):
+        super(SpectraPro2300i, self).__init__()
+
+        # set up spectrograph
+        self.serial_busy = False
+        port = 'COM5'
+        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
+                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
+        # get startup values
+        self.grating = float(self.write_command('?GRATING')[0])
+        numbers = self.write_command('?GRATINGS')
+        self.num_gratings = int((len(numbers)-8)/2)
+        self.grating_densities = np.zeros(self.num_gratings)
+        self.grating_blazes = np.zeros(self.num_gratings)
+        for i in range(self.num_gratings):
+            self.grating_densities[i] = numbers[i*3 + 1]
+            self.grating_blazes[i] = numbers[i * 3 + 2]
+        self.center_wl = float(self.write_command('?NM')[0])
+        print(self.center_wl)
+        print(self.grating_densities)
+        print(self.grating_blazes)
+        print(self.grating)
+        print('SP2300 grating info: ', numbers)
+        print('SP2300 grating densities: ',self.grating_densities)
+        print('SP2300 grating blazes: ',self.grating_blazes)
+        print('SP2300 selected grating: ',self.grating)
+
+        # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
+        self.hardware_params=hardware_params
+        # set parameter dict
+        self.parameter_dict = defaultdict()
+        """ Set up the parameter dict. 
+        Here, all properties of parameters to be handled by the parameter dict are defined."""
+        
+        self.parameter_display_dict = defaultdict(dict)
+        
+        self.parameter_dict['central_wave'] = self.center_wl
+        self.parameter_dict['grating'] = self.grating
+        
+        self.parameter_display_dict['central_wave']['val'] = self.center_wl
+        self.parameter_display_dict['central_wave']['unit'] = ' nm'
+        self.parameter_display_dict['central_wave']['min'] = 200.00
+        self.parameter_display_dict['central_wave']['max'] = 1100.00
+        self.parameter_display_dict['central_wave']['read'] = False
+        
+        self.parameter_display_dict['grating']['val'] = self.grating
+        self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['grating']['max'] = 3
+        self.parameter_display_dict['grating']['read'] = False
+
+        # set up parameter dict that only contains value. (faster to access)
+        self.parameter_dict = {}
+        for key in self.parameter_display_dict.keys():
+            self.parameter_dict[key] = self.parameter_display_dict[key]['val']
+    
+    def write_command(self, cmd):
+        """ Command to write to serial handles timeout by blocking serial commands
+        Args:
+            ser: serial object
+            cmd: write command as defined in PI API
+
+        Returns: read string with only digit content. For troubleshooting, consider printing
+        the entire answer string
+        """
+        cmd_bytes = cmd.encode('ASCII')
+        self.ser.write(cmd_bytes + b"\r")
+        out = bytearray()
+        char = b""
+        missed_char_count = 0
+        while char != b"k":
+            char = self.ser.read()
+            if char == b"":  # handles a timeout here
+                missed_char_count += 1
+                self.serial_busy = True
+                time.sleep(0.1)
+            out += char
+        self.serial_busy = False
+        return re.findall(r'\d+', out.decode().strip())
+   
+    def set_parameter(self, parameter, value):
+        """REQUIRED. This function defines how changes in the parameter tree are handled.
+        In devices with workers, a pause of continuous acquisition might be required. """
+        if parameter == 'central_wave':
+            cmd = f'{value:0.3f} GOTO'
+            self.write_command(cmd)
+            self.parameter_dict['center_wave'] = value
+            self.center_wl = value
+        elif parameter == 'grating':
+            cmd = f'{value:1.0f} GRATING'
+            self.write_command(cmd)
+            self.parameter_dict['grating'] = value
+            self.grating = value
+
+    def get_hardware_parameters(self):
+        """
+            Returns the hardware parameters of the monochromator
+            output:
+                - hardware_parameters (dict): A dictionnary of all hardware parameters including:
+                    - f
+                    - delta
+                    - gamma
+                    - n0
+                    - offset_adjust
+                    - d_grating
+                    - x_pixel
+                    - curvature
+
+        """
+        return self.hardware_params
+    def get_monochromator_parameters(self):
+        """
+            Returns the current parameters of the monochromator.
+            output:
+                - central_wavelength (np.float): the central wavelength in nm
+                - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
+        """
+        return self.center_wl, self.grating_densities[int(self.grating)]
+
+

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -35,6 +35,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.grating_densities[i] = numbers[i*3 + 1]
             self.grating_blazes[i] = numbers[i * 3 + 2]
         self.center_wl = float(self.write_command('?NM')[0])
+        self.mirror = float(self.write_command('?MIR')[0])
         print(self.center_wl)
         print(self.grating_densities)
         print(self.grating_blazes)
@@ -55,6 +56,7 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_dict['central_wave'] = self.center_wl
         self.parameter_dict['grating'] = self.grating
+        self.parameter_dict['mirror'] = self.mirror
         
         self.parameter_display_dict['central_wave']['val'] = self.center_wl
         self.parameter_display_dict['central_wave']['unit'] = ' nm'
@@ -64,8 +66,15 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_display_dict['grating']['val'] = self.grating
         self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['mirror']['min'] = 1
         self.parameter_display_dict['grating']['max'] = 3
         self.parameter_display_dict['grating']['read'] = False
+
+        self.parameter_display_dict['mirror']['val'] = self.mirror
+        self.parameter_display_dict['mirror']['unit'] = ' mirror'
+        self.parameter_display_dict['mirror']['min'] = 0
+        self.parameter_display_dict['mirror']['max'] = 1
+        self.parameter_display_dict['mirror']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -109,6 +118,11 @@ class SpectraPro2300i(QtCore.QThread):
             self.write_command(cmd)
             self.parameter_dict['grating'] = value
             self.grating = value
+        elif parameter == 'mirror':
+            cmd = f'{value:1.0f} MIRROR'
+            self.write_command(cmd)
+            self.parameter_dict['mirror'] = value
+            self.mirror = value
 
     def get_hardware_parameters(self, name):
         """

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -264,9 +264,13 @@ class StresingCamera(QtCore.QThread):
 
             if self.hardware_params['calibrated']:
 
+                pixel_size_mm = 24 / 1E3  # specs of Sresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of stresing
+
                 wl_center = self.center_wavelength
                 m_order = 1
-                px = np.linspace(1,1024,1024)
+                px = np.linspace(1,1010,1010)
 
                 # calibration from notebook
                 f=self.hardware_params['f']
@@ -280,14 +284,17 @@ class StresingCamera(QtCore.QThread):
 
                 n = px - (n0 + offset_adjust * wl_center)
 
-                # print('psi top', m_order* wl_center)
-                # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
-
                 psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
                 eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
                 self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+
             else:
+
+                pixel_size_mm = 24 / 1E3  # specs of Stresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of Stresing
+
                 # Calculate linear dispersion (nm/mm)
                 dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
@@ -299,8 +306,7 @@ class StresingCamera(QtCore.QThread):
 
                 # Wavelength at each pixel
                 self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-                # Refine the calibration using a mercury spectral lamp
-                self.wavelengths = self.hardware_params['calibrationThirdOrder']*self.wavelengths**2 + self.hardware_params['calibrationSlope']*self.wavelengths + self.hardware_params['calibrationOffset']
+
         else:
             self.wavelengths= self.hardware_params['num_pixels']
             logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength'%datetime.datetime.now())
@@ -313,7 +319,7 @@ class StresingCamera(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
@@ -332,6 +338,7 @@ class StresingCamera(QtCore.QThread):
             time.sleep(0.01)
             self.new_spectrum = False
         self.spec = np.array(self.spectrum[13:-1])
+        self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
         return self.spec
 

--- a/src/main.py
+++ b/src/main.py
@@ -408,6 +408,16 @@ class MainInterface(QtWidgets.QMainWindow):
         # Rebuild parameter tree UI (existing code)
         self.create_parameter_array()
 
+        self.parameter = {}
+        for device in self.parameter_dic:
+            for param in self.parameter_dic[device]:
+                self.parameter[param] = self.parameter_dic[device][param]['val']
+        self.DataHandling.close()
+        self.DataHandling = DataHandling(self.parameter, self.spec_length)
+        self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
+        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
+        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+
         logger.info(
             f"Switched to spectrometer: {new_name} "
             f"(spec_length={self.spec_length})"

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -564,13 +564,60 @@ class FitTemporalBeamCalibration(QtCore.QThread):
         # Loop through each wavelength 
         max_chirp_values = []
         wavelength_values = []
-        for wls in range(self.data.shape[1]):
-            intensity_column = self.data[:, wls]
-            max_row_index = np.argmax(intensity_column)
-            if max_row_index == 0:
-                continue
-            max_chirp_values.append(self.chirp_array[max_row_index])
-            wavelength_values.append(self.wavelength_array[wls])
+        # for wls in range(self.data.shape[1]):
+        #     intensity_column = self.data[:, wls]
+        #     max_row_index = np.argmax(intensity_column)
+        #     if max_row_index == 0:
+        #         continue
+        #     max_chirp_values.append(self.chirp_array[max_row_index])
+        #     wavelength_values.append(self.wavelength_array[wls])
+
+
+        # ----- Find starting wavelength -----
+        # wavelength with the strongest overall signal
+        start_col = np.argmax(np.max(self.data, axis=0))
+
+        # maximum there
+        start_row = np.argmax(self.data[:, start_col])
+
+        indices = np.zeros(self.data.shape[1], dtype=int)
+        indices[start_col] = start_row
+
+        # Search window in chirp units
+        window = 1000   # fs²/rad²
+
+        dchirp = np.abs(self.chirp_array[1] - self.chirp_array[0])
+        N = int(window / dchirp)
+
+        # ---------- Track toward longer wavelengths ----------
+        for col in range(start_col + 1, self.data.shape[1]):
+
+            prev = indices[col-1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # ---------- Track toward shorter wavelengths ----------
+        for col in range(start_col-1, -1, -1):
+
+            prev = indices[col+1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # Final arrays
+        max_chirp_values = self.chirp_array[indices]
+        wavelength_values = self.wavelength_array
+
+
         max_chirp_values = np.array(max_chirp_values)
         wavelength_values = np.array(wavelength_values)
         omega_values = 0.5*co.waveToAngFreq(np.array(wavelength_values) * 1e-9) # rad Hz

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -85,7 +85,7 @@ class VerticalBeamCalibrationMeasurement(QtCore.QThread):
                 self.vertical_calibration_data['intensities']=self.intensities
                 self.vertical_calibration_data['rows']=self.rows
                 if i>=1:
-                    self.send_intensities.emit(self.rows,self.intensities[1:])
+                    self.send_intensities.emit(self.rows,self.intensities)
         self.vertical_calibration_data['intensities']=self.intensities
         self.vertical_calibration_data['rows']=self.rows
         self.send_vertical_calibration_data.emit(('vertical_calibration_data',self.vertical_calibration_data))
@@ -423,11 +423,12 @@ class ChirpCalibrationMeasurement(QtCore.QThread):
                                 'data' : np.array(self.intensities)
                                 }
                             if i>=3:
-                                indexes = np.where(
-                                    (self.wls >= (self.carrierWls/2 - 100)) &
-                                    (self.wls <= (self.carrierWls/2 + 100))
-                                )[0]
-                                self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                # indexes = np.where(
+                                #     (self.wls >= (self.carrierWls/2 - 100)) &
+                                #     (self.wls <= (self.carrierWls/2 + 100))
+                                # )[0]
+                                # self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                self.send_chirp.emit(self.chirp[3:i],self.wls,np.array(self.intensities)[3:i,:])
         self.send_chirp_calibration_data.emit(('chirp_calibration_raw_data',self.Chirp_calibration_data))
         self.sendProgress.emit(100)
         self.stop()
@@ -775,6 +776,7 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         data_filtered_region = data_filtered[1:-1, mask]
         data_integrated = np.sum(data_filtered_region, axis=1)
         data_integrated_normalized = data_integrated/np.max(data_integrated)
+        data_integrated_normalized = -(data_integrated_normalized-np.max(data_integrated_normalized))
 
         self.sendCrossCorrelationRegion.emit(delay_array_region, data_integrated_normalized)
         self.delay_calibration_processed_data={
@@ -799,7 +801,8 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         C0 = np.min(self.intensity)
 
         p0 = [A0, mu0, sigma0, C0]
-        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0)
+        bounds = ([-np.inf, self.delay.min(), 0, -np.inf], [ np.inf, self.delay.max(), np.inf, np.inf])
+        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0, bounds=bounds)
         A, mu, sigma, C = popt
         self.fitted_intensity = (A * np.exp(-(self.delay - mu)**2 / (2 * sigma**2)) + C)
         self.sendCrossCorrelationRegionFit.emit(self.delay, self.fitted_intensity, mu, sigma)

--- a/src/measurements/MDCSClasses.py
+++ b/src/measurements/MDCSClasses.py
@@ -191,20 +191,20 @@ class BoxcarGeometry(QtCore.QThread):
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
                 'C' : self.t_secondary[i]*np.ones(Nb_step),
-                'B' : self.t_scanned,
+                'B' : self.t_scanned.copy(),
                 'LO' : self.t_scanned-self.t_LO*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - rephasing':
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
-                'C' : self.t_scanned,
+                'C' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - non rephasing':
             self.group_delay = {
                 'C' : np.zeros(Nb_step),
-                'A' : self.t_scanned,
+                'A' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
@@ -215,6 +215,17 @@ class BoxcarGeometry(QtCore.QThread):
                 'A' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
+        elif self.measurement_type == 'LO scan':
+            self.group_delay = {
+                'C' : np.zeros(Nb_step),
+                'B' : np.zeros(Nb_step),
+                'A' : np.zeros(Nb_step),
+                'LO' : self.t_scanned.copy()
+            }
+        
+        # To give the right delay between pulse
+        for key in self.group_delay:
+            self.group_delay[key] *= -1
 
     def phase_cycling(self, j):
         '''


### PR DESCRIPTION
- The Pixis 256 can be use, ROI is define so the camera is acting like a 1D detector (1024 pixels)
- The monochromator is can be used by the Stresing and the Pixis
- Changing the camera involves closing and re-initiating the DataHandling because the number of parameters is changing. This is done in the main.