### PR TITLE
Fix/spectrapro monochromator

### DIFF
--- a/manual/camera_spectrometer.md
+++ b/manual/camera_spectrometer.md
@@ -1,0 +1,5 @@
+# Camera and spectrometer
+
+Colbert can be used with two cameras (Stresing and Pixis) plugged to one spoectrometer. Everything is managed in the intruments.py where you can add or removed devices. The spectrometer is the main device where the cameras could be attached, meaning that all camera parameters are child of the parent spectrometer. Those parameters are all saved and managed through Data Handling. 
+
+On the main panel, on the top right, you can find a sliding menu where there is a list of the connected cameras. Selecting another camera reset completely Data Handling beacause the number of parameter is changing between cameras and also the length of the sensor may be different. For those reasons, it is easier to reset. All the other calibrations that were not associated with the camera will be loaded back. However, the connection between the beam explorer and Data Handling seems to be lost. 

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -91,8 +91,12 @@ class DataHandling(QtCore.QThread):
         hardware parameter is added to the deque"""
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
+
         for idx, param in enumerate(self.parameter):
             self.parameter_queue[param].append(parameter[idx])
+
+        # for param, value in zip(self.parameter_queue, parameter):
+        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -308,7 +312,10 @@ class DataHandling(QtCore.QThread):
         Parameters:
             new_length (int): The new number of pixels in the spectrum.
         """
-        self.speclength = new_length
+        if isinstance(new_length, tuple):
+            self.speclength = new_length[1]  # or [0], whichever is intended
+        else:
+            self.speclength = new_length
 
         # Reset spectrum buffer
         self.spec = np.zeros((self.speclength, 0))  # zero columns, rows = new_length
@@ -331,6 +338,47 @@ class DataHandling(QtCore.QThread):
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")
+
+    def close(self):
+        """Safely stop Qt thread + worker before re-instantiating DataHandling."""
+
+        # 1. Stop worker thread safely (if it has a stop flag)
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.terminate = True  # your custom flag (optional)
+        except:
+            pass
+
+        # 2. Disconnect signals (VERY important)
+        try:
+            if hasattr(self, "bufferSaveSignal"):
+                self.bufferSaveSignal.disconnect()
+        except:
+            pass
+
+        # 3. Quit Qt thread event loop
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.quit()
+                self.thread.wait()   # blocks until fully stopped
+        except:
+            pass
+
+        # 4. Delete worker safely
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.deleteLater()
+                self.BufferWorker = None
+        except:
+            pass
+
+        # 5. Delete thread safely
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.deleteLater()
+                self.thread = None
+        except:
+            pass
 
 
 class BufferWorker(QtCore.QObject):

--- a/src/GUI/BeamExplorer.py
+++ b/src/GUI/BeamExplorer.py
@@ -188,7 +188,7 @@ class BeamWidget(QWidget):
 
     def set_phase_manually(self):
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
     def toggle_beam_to_slm(self):
         '''
@@ -217,7 +217,7 @@ class BeamWidget(QWidget):
         self.beam.set_beamVerticalDelimiters([int(self.delimiter_table.item(0,0).text()),int(self.delimiter_table.item(0,1).text())])
         self.beam.set_beamHorizontalDelimiters([int(self.delimiter_table.item(1,0).text()),int(self.delimiter_table.item(1,1).text())])
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
         return self.name,self.beam
 

--- a/src/GUI/main_GUI.ui
+++ b/src/GUI/main_GUI.ui
@@ -2716,6 +2716,11 @@ p, li { white-space: pre-wrap; }
              <string>2Q</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>LO scan</string>
+            </property>
+           </item>
           </widget>
           <widget class="QLabel" name="Measurement_TLO_delay_label">
            <property name="geometry">

--- a/src/compute/beams.py
+++ b/src/compute/beams.py
@@ -481,10 +481,6 @@ class Beam:
         elif TaylorPrefactorFlag == 'remove':
             coef = [c / f for c, f in zip(coef, TaylorFactor)]
 
-        # Add minus sign to the group delay (linear term)
-        if len(coef) > 1:
-            coef[1] *= -1
-
         return P(coef)
     
     @staticmethod

--- a/src/drivers/CryoDemo.py
+++ b/src/drivers/CryoDemo.py
@@ -3,11 +3,11 @@
 Created on Thu Sep  1 13:26:53 2022
 
 @author: NanoUltrafast2
-Hardware class to controll cryostat. All hardware classes require a definition of
-parameter_dict (set write and read parameter)
-parameter_display_dict (set Spinbox options)
-set_parameter function (assign set functions)
-
+Simulated cryostat driver used when no CryoPasqal hardware is available.
+Mirrors the parameter names (drivers.Optidry250.CryoPasqal.parameter_display_dict)
+and the command methods used by GUI.cryostattab.CryostatTab, so the dedicated
+cryostat page and the generic parameter tree behave the same way in demo mode
+as they do with real hardware.
 """
 
 import numpy as np
@@ -19,94 +19,203 @@ from collections import defaultdict
 class CryoDemo(QtCore.QThread):
 
     name = 'CryoDemo'
-    type = 'Cryostatas'
-    
+    type = 'Cryostat'
+
     def __init__(self):
         super(CryoDemo, self).__init__()
 
-
-        # set parameter dict
-        self.parameter_dict = defaultdict()
-        
-        # setting up variables, open array
-        self.set_T = []
-        self.current_T = []
-        self.stop = False
         self.parameter_display_dict = defaultdict(dict)
-        self.parameter_display_dict['set_T']['val'] = 5
-        self.parameter_display_dict['set_T']['unit'] = ' K'
-        self.parameter_display_dict['set_T']['max'] = 1000
-        self.parameter_display_dict['set_T']['read'] = False
-        self.parameter_display_dict['current_T']['val'] = 5
-        self.parameter_display_dict['current_T']['unit'] = ' K'
-        self.parameter_display_dict['current_T']['max'] = 1000
-        self.parameter_display_dict['current_T']['read'] = True
+
+        # --- Setpoint and Loop settings ---
+        self.parameter_display_dict['Set_T']['val'] = 5.0
+        self.parameter_display_dict['Set_T']['unit'] = ' K'
+        self.parameter_display_dict['Set_T']['min'] = 0
+        self.parameter_display_dict['Set_T']['max'] = 400
+        self.parameter_display_dict['Set_T']['read'] = False
+
+        self.parameter_display_dict['Regulation_Loop']['val'] = 1
+        self.parameter_display_dict['Regulation_Loop']['unit'] = ' loop'
+        self.parameter_display_dict['Regulation_Loop']['min'] = 1
+        self.parameter_display_dict['Regulation_Loop']['max'] = 2
+        self.parameter_display_dict['Regulation_Loop']['read'] = False
+
+        # --- Temperatures (Channels A to E) ---
+        for channel in ['ChannelA_T', 'ChannelB_T', 'ChannelC_T', 'ChannelD_T', 'ChannelE_T']:
+            self.parameter_display_dict[channel]['val'] = 5.0
+            self.parameter_display_dict[channel]['unit'] = ' K'
+            self.parameter_display_dict[channel]['min'] = 0
+            self.parameter_display_dict[channel]['max'] = 400
+            self.parameter_display_dict[channel]['read'] = True
+
+        # --- Pressures (Channels F and G) ---
+        self.parameter_display_dict['PressureF']['val'] = 101300.0
+        self.parameter_display_dict['PressureF']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureF']['min'] = 0
+        self.parameter_display_dict['PressureF']['max'] = 200000
+        self.parameter_display_dict['PressureF']['read'] = True
+
+        self.parameter_display_dict['PressureG']['val'] = 101300.0
+        self.parameter_display_dict['PressureG']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureG']['min'] = 0
+        self.parameter_display_dict['PressureG']['max'] = 200000
+        self.parameter_display_dict['PressureG']['read'] = True
+
+        # --- PID Parameters ---
+        self.parameter_display_dict['Pid_P']['val'] = 0.0
+        self.parameter_display_dict['Pid_P']['unit'] = ' P'
+        self.parameter_display_dict['Pid_P']['min'] = 0
+        self.parameter_display_dict['Pid_P']['max'] = 1000
+        self.parameter_display_dict['Pid_P']['read'] = False
+
+        self.parameter_display_dict['Pid_I']['val'] = 0.0
+        self.parameter_display_dict['Pid_I']['unit'] = ' I'
+        self.parameter_display_dict['Pid_I']['min'] = 0
+        self.parameter_display_dict['Pid_I']['max'] = 1000
+        self.parameter_display_dict['Pid_I']['read'] = False
+
+        self.parameter_display_dict['Pid_D']['val'] = 0.0
+        self.parameter_display_dict['Pid_D']['unit'] = ' D'
+        self.parameter_display_dict['Pid_D']['min'] = 0
+        self.parameter_display_dict['Pid_D']['max'] = 1000
+        self.parameter_display_dict['Pid_D']['read'] = False
+
+        # --- Status and Compressor ---
+        self.parameter_display_dict['OnOff_comp']['val'] = 0
+        self.parameter_display_dict['OnOff_comp']['unit'] = ' state'
+        self.parameter_display_dict['OnOff_comp']['min'] = 0
+        self.parameter_display_dict['OnOff_comp']['max'] = 1
+        self.parameter_display_dict['OnOff_comp']['read'] = False
+
+        self.parameter_display_dict['Stability']['val'] = "In progress"
+        self.parameter_display_dict['Stability']['unit'] = ''
+        self.parameter_display_dict['Stability']['read'] = True
+
+        self.parameter_display_dict['Critical_State']['val'] = "OK"
+        self.parameter_display_dict['Critical_State']['unit'] = ''
+        self.parameter_display_dict['Critical_State']['read'] = True
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
         for key in self.parameter_display_dict.keys():
             self.parameter_dict[key] = self.parameter_display_dict[key]['val']
 
+        # --- History for stability calculation ---
+        self.temp_history = []
+        self.stability_threshold = 0.05
+        self.stability_window = 30
 
-        
-        # defining waitTime
-        self.waitTime = 0.1
-
-        # start updating temp
-        self.UpdateWorker = UpdateWorker()
-        self.UpdateWorker.new_T.connect(self.update_temp)
+        # start simulated background polling worker
+        self.UpdateWorker = DemoWorker(self.parameter_dict['ChannelA_T'], self.parameter_dict['Set_T'])
+        self.UpdateWorker.new_T.connect(self.update_all_data)
         self.UpdateWorker.start()
 
-    def set_parameter(self,parameter,value):
-        if parameter == 'set_T':
-            self.update_set_T(value)
+    def set_parameter(self, parameter, value):
+        """Called by the generic parameter tree (banderole) for writable params."""
+        self.parameter_dict[parameter] = value
+        if parameter in self.parameter_display_dict:
+            self.parameter_display_dict[parameter]['val'] = value
+
+        if parameter == 'Set_T':
             self.UpdateWorker.target = value
+        elif parameter == 'OnOff_comp':
+            self.set_compressor_state(bool(int(value)))
 
-    def update_set_T(self, set_temperature):
-        #set temperature to some degree K
-        #requests.put("http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature",json = {"platformTargetTemperature": set_temperature})
-        
-        print(f'Temperature set to {set_temperature}')
-              
-    def start_cool(self):
-        #start chamber cooldown
-        #requests.post('http://10.131.3.6:47101/v1/controller/methods/cooldown()')
-        
-        print("Cooldown has started")
-        
-    def start_warm(self):
-        # warmup the chamber
-        # requests.post('http://10.131.3.6:47101/v1/controller/methods/warmup()')
-        print("Warming Up")
-        
-    def update_temp(self, new_T):
-        self.parameter_dict['current_T'] = new_T
+    # --- Simulated hardware commands, mirror CryoPasqal's API used by CryostatTab ---
+
+    def set_temperature_setpoint(self, loop, target_temp):
+        self.parameter_dict['Set_T'] = target_temp
+        self.parameter_display_dict['Set_T']['val'] = target_temp
+        self.UpdateWorker.target = target_temp
+        print(f'[Demo] Loop {loop} setpoint updated to: {target_temp} K')
+
+    def set_heater_range(self, loop, range_level):
+        print(f'[Demo] Loop {loop} Heater Range updated to: {range_level}')
+
+    def set_pid_parameters(self, loop, p, i, d):
+        self.parameter_dict['Pid_P'] = p
+        self.parameter_dict['Pid_I'] = i
+        self.parameter_dict['Pid_D'] = d
+        print(f'[Demo] Loop {loop} PID parameters updated: P={p}, I={i}, D={d}')
+
+    def set_compressor_state(self, state_on):
+        self.parameter_dict['OnOff_comp'] = int(bool(state_on))
+        self.parameter_display_dict['OnOff_comp']['val'] = int(bool(state_on))
+        self.UpdateWorker.compressor_on = bool(state_on)
+        print(f"[Demo] Compressor set to: {'ON' if state_on else 'OFF'}")
+
+    def reset_compressor_alarm(self):
+        self.parameter_dict['Critical_State'] = 'OK'
+        self.parameter_display_dict['Critical_State']['val'] = 'OK'
+        print('[Demo] Alarm reset command sent.')
+
+    def update_all_data(self, data_list):
+        """Slot receiving simulated sensor data from the background worker."""
+        def assign_val(key, val):
+            self.parameter_dict[key] = val
+            self.parameter_display_dict[key]['val'] = val
+
+        assign_val('ChannelA_T', data_list[0])
+        assign_val('ChannelB_T', data_list[1])
+        assign_val('ChannelC_T', data_list[2])
+        assign_val('ChannelD_T', data_list[3])
+        assign_val('ChannelE_T', data_list[4])
+        assign_val('PressureF', data_list[5])
+        assign_val('PressureG', data_list[6])
+
+        self.calculate_stability(data_list[0])
+
+    def calculate_stability(self, current_temp):
+        self.temp_history.append(current_temp)
+        if len(self.temp_history) > self.stability_window:
+            self.temp_history.pop(0)
+
+        status = "In progress"
+        if len(self.temp_history) >= self.stability_window:
+            temp_range = max(self.temp_history) - min(self.temp_history)
+            if temp_range <= self.stability_threshold:
+                status = "Stable"
+
+        self.parameter_dict['Stability'] = status
+        self.parameter_display_dict['Stability']['val'] = status
 
 
+class DemoWorker(QtCore.QThread):
+    """Background worker that simulates the cryostat drifting toward its setpoint."""
 
-class UpdateWorker(QtCore.QThread):
+    new_T = QtCore.pyqtSignal(list)
 
-    new_T = QtCore.pyqtSignal(float)
-
-    def __init__(self):
-        super(UpdateWorker, self).__init__()
-        self.currentT = []
+    def __init__(self, initial_temp, initial_target):
+        super(DemoWorker, self).__init__()
         self.stop = False
-        self.waitTime = 0.1
-        self.target = 300
+        self.waitTime = 0.5
+        self.target = initial_target
+        self.current_T = initial_temp
+        self.compressor_on = False
+        self.cooling_rate = 0.5  # K per tick toward target when compressor is on
 
     def run(self):
         while not self.stop:
-            # calling the read temperature function
-            self.readtemp = self.read_T()
-
-            # waiting to remeasure the temperature
+            self.new_T.emit(self.simulate_step())
             time.sleep(self.waitTime)
-            self.new_T.emit(self.readtemp)
 
-    def read_T(self):
-        #read the current platform target temperature
-        #resp=requests.get('http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature')
-        target = self.target + np.random.rand(1)
-        return target
+    def simulate_step(self):
+        # Drift current_T toward target, faster when the compressor is on
+        rate = self.cooling_rate if self.compressor_on else self.cooling_rate * 0.1
+        delta = self.target - self.current_T
+        step = np.clip(delta, -rate, rate)
+        noise = (np.random.rand() - 0.5) * 0.05
+        self.current_T = self.current_T + step + noise
 
+        pressure_f = 101300.0 + (np.random.rand() - 0.5) * 50
+        pressure_g = 101300.0 + (np.random.rand() - 0.5) * 50
+
+        # Other channels loosely track the primary channel with small fixed offsets
+        return [
+            self.current_T,
+            self.current_T + 0.5,
+            self.current_T + 1.0,
+            self.current_T - 0.5,
+            self.current_T - 1.0,
+            pressure_f,
+            pressure_g,
+        ]

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -59,27 +59,33 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
-    # Shamrock grating parameters
-    grating_params={
-        'focal_length_mm':163,
-        'delta':np.float64(-0.20488367116307532),
-        'gamma':np.float64(2.021864300924973),
-        'n0':np.float64(511.0), # Central pixel
-        'offset_adjust':0,
-        'd_grating':np.float64(6666.666666666667),
-        'x_pixel':26000.0,
-        'curvature':np.float64(3.1224154313329654e-06),
-    }
-    # SpectraPro 2300i grating parameters
-    grating_params = {
+    grating_params_stresing={
         'focal_length_mm':300,
-        'delta':np.float64(0),
-        'gamma':np.float64(0),
-        'n0':np.float64(511.0), # Central pixel
+        'f':np.float64(305381928.6149399),
+        'delta':np.float64(0.11432112488955509),
+        'gamma':np.float64(0.5337955112241486),
+        'n0':np.float64(539.4), # Central pixel
         'offset_adjust':0,
-        'd_grating':None,
-        'x_pixel':None,
-        'curvature':np.float64(0),
+        'd_grating':833.3333333333334,
+        'x_pixel':24000.0,
+        'curvature':np.float64(5.736575254871788e-07),
+    }
+    f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
+    grating_params_pixis = {
+        'focal_length_mm':300,
+        'f':np.float64(300000000.0),
+        'delta':np.float64(0.06),
+        'gamma':np.float64(0.5),
+        'n0':np.float64(516.6), # Central pixel
+        'offset_adjust':0,
+        'd_grating':833.3333333333334,
+        'x_pixel':26000,
+        'curvature':np.float64(0.0),
+    }
+
+    grating_params = {
+        'Stresing': grating_params_stresing,
+        'Pixis': grating_params_pixis
     }
     Monochrom = SpectraPro2300i(grating_params) 
 
@@ -92,7 +98,7 @@ def load_instruments():
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
-        'calibrated': False,
+        'calibrated': True,
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
@@ -100,7 +106,7 @@ def load_instruments():
     pixis_params = {
         'pixel_size_mm':26e-3,
         'num_pixels':1024,
-        'calibrated':False,
+        'calibrated':True,
         'calibrationThirdOrder':0,
         'calibrationSlope':0,
         'calibrationOffset':0

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -10,6 +10,8 @@ from drivers.SLMDemo import SLMDemo
 from drivers.Stresing import StresingCamera
 from drivers.Shamrock import Shamrock 
 from drivers.Optidry250 import CryoPasqal
+from drivers.Pixis import Pixis
+from drivers.SpectraPro2300i import SpectraPro2300i
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +59,9 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
+    # Shamrock grating parameters
     grating_params={
         'focal_length_mm':163,
-        'f':np.float64(330605663.74965495),
         'delta':np.float64(-0.20488367116307532),
         'gamma':np.float64(2.021864300924973),
         'n0':np.float64(511.0), # Central pixel
@@ -68,11 +70,25 @@ def load_instruments():
         'x_pixel':26000.0,
         'curvature':np.float64(3.1224154313329654e-06),
     }
-    Monochrom = Shamrock(grating_params) 
+    # SpectraPro 2300i grating parameters
+    grating_params = {
+        'focal_length_mm':300,
+        'delta':np.float64(0),
+        'gamma':np.float64(0),
+        'n0':np.float64(511.0), # Central pixel
+        'offset_adjust':0,
+        'd_grating':None,
+        'x_pixel':None,
+        'curvature':np.float64(0),
+    }
+    Monochrom = SpectraPro2300i(grating_params) 
+
+    
+    
     devices['Monochrom'] = Monochrom 
     logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
 
-    # initialize StresingDemo
+    # initialize Cameras
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
@@ -80,6 +96,14 @@ def load_instruments():
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
+    }
+    pixis_params = {
+        'pixel_size_mm':26e-3,
+        'num_pixels':1024,
+        'calibrated':False,
+        'calibrationThirdOrder':0,
+        'calibrationSlope':0,
+        'calibrationOffset':0
     }
 
     spectrometers = {}
@@ -91,6 +115,14 @@ def load_instruments():
         logger.info('%s Stresing connected' % datetime.datetime.now())
     except Exception as e:
         logger.warning(f'Stresing failed: {e}')
+
+    try:
+        camera = Pixis(pixis_params)
+        spectrometers['Pixis'] = camera
+        camera.attach_to_monochromator(Monochrom)
+        logger.info('%s Pixis connected' % datetime.datetime.now())
+    except Exception as e:
+        logger.warning(f'Pixis failed: {e}')
 
     try:
         from drivers.OceanSpectrometer import OceanSpectrometer

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -64,7 +64,7 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['unit'] = ' celsius'
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
-        self.parameter_display_dict['sensor_T']['read'] = True
+        self.parameter_display_dict['sensor_T']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -223,8 +223,9 @@ class Pixis(QtCore.QThread):
         spectrum = spectrum[0, :]
         return spectrum
 
-    def update_temperature(self,temperature):
+    def update_temperature(self, temperature):
         self.parameter_dict['sensor_T'] = temperature
+        self.parameter_display_dict['sensor_T']['val'] = temperature
 
 
 class CameraWorker(QtCore.QThread):

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -119,7 +119,8 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array()
+        self.calculate_wavelength_array()
+        return self.wavelengths
 
     def calculate_wavelength_array(self):
         """
@@ -136,32 +137,32 @@ class Pixis(QtCore.QThread):
             focal_length_mm = self.hardware_params['focal_length_mm']
             num_pixels = self.hardware_params['num_pixels']
         
-        calibrated = False
-        if calibrated:
-            pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 300  # specs of SP2150
-            num_pixels = 1024  # specs of PIXIS
+        if self.hardware_params['calibrated']:
 
-            #
+            pixel_size_mm = 26 / 1E3  # specs of PIXIS
+            focal_length_mm = 300  # specs of SP2300
+            num_pixels = 1024  # specs of PIXIS
 
             wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
             # calibration from notebook
-            f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
-
-
+            f=self.hardware_params['f']
+            delta=self.hardware_params['delta']
+            gamma=self.hardware_params['gamma']
+            n0=self.hardware_params['n0']
+            offset_adjust=self.hardware_params['offset_adjust']
+            d_grating=self.hardware_params['d_grating']
+            x_pixel=self.hardware_params['x_pixel']
+            curvature=self.hardware_params['curvature']
 
             n = px - (n0 + offset_adjust * wl_center)
-
-            # print('psi top', m_order* wl_center)
-            # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
 
             psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
             eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
-            wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+            self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
             focal_length_mm = 300  # specs of SP2150
@@ -177,9 +178,7 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-
-        return wavelengths
+            self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
     def attach_to_monochromator(self,monochromator):
         """
@@ -189,7 +188,7 @@ class Pixis(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Pixis'))
     
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -22,21 +22,21 @@ from PyQt5 import QtCore
 from collections import defaultdict
 from pylablib.devices import PrincetonInstruments
 import time
-import serial
 import re
 
 class Pixis(QtCore.QThread):
 
     name = 'Pixis'
     
-    def __init__(self):
+    def __init__(self, hardware_params):
         super(Pixis, self).__init__()
 
         #self.camera.start()
-        self.wavelength =  np.linspace(200,1000,1024) # get property from Worker
+        self.wavelength = np.linspace(200,1000,1024) # get property from Worker
         self.px0 = np.linspace(1,1024,1024)
-        self.spec_length = (252,1024) # get property from Worker
+        self.spec_length = 1024 #(252,1024) # get property from Worker
         self.image = np.zeros(self.spec_length)
+        self.hardware_params = hardware_params
 
         # Indicate shutter, required to discriminate between different detectors
         self.shutter = True
@@ -46,30 +46,6 @@ class Pixis(QtCore.QThread):
         self.int_time = 100
         self.binned_spec = np.zeros(self.spec_length)
         self.new_spectrum = False
-
-        # set up spectrograph
-        self.serial_busy = False
-        port = 'COM6'
-        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
-                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
-        # get startup values
-        self.grating = float(self.write_command('?GRATING')[0])
-        numbers = self.write_command('?GRATINGS')
-        self.num_gratings = int((len(numbers)-8)/2)
-        self.grating_densities = np.zeros(self.num_gratings)
-        self.grating_blazes = np.zeros(self.num_gratings)
-        for i in range(self.num_gratings):
-            self.grating_densities[i] = numbers[i*3 + 1]
-            self.grating_blazes[i] = numbers[i * 3 + 2]
-        self.center_wl = float(self.write_command('?NM')[0])
-        print(self.center_wl)
-        print(self.grating_densities)
-        print(self.grating_blazes)
-        print(self.grating)
-        print('SP2150 grating info: ', numbers)
-        print('SP2150 grating densities: ',self.grating_densities)
-        print('SP2150 grating blazes: ',self.grating_blazes)
-        print('SP2150 selected grating: ',self.grating)
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -89,14 +65,6 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
         self.parameter_display_dict['sensor_T']['read'] = True
-        self.parameter_display_dict['center_wl']['val'] = self.center_wl
-        self.parameter_display_dict['center_wl']['unit'] = ' nm'
-        self.parameter_display_dict['center_wl']['max'] = 2000
-        self.parameter_display_dict['center_wl']['read'] = False
-        self.parameter_display_dict['grating']['val'] = self.grating
-        self.parameter_display_dict['grating']['unit'] = ' grat'
-        self.parameter_display_dict['grating']['max'] = 3
-        self.parameter_display_dict['grating']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -108,6 +76,10 @@ class Pixis(QtCore.QThread):
         print(PrincetonInstruments.list_cameras())
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
+
+        # set the ROI so the camera is acting like a 1D array of 1024 pixels
+        roi = {"x": 0, "width": 1024, "x_binning": 1, "y": 0, "height": 1, "y_binning": 1}
+        self.camera.set_attribute_value("ROIs", [roi])
 
         # initialize camera
         self.worker = CameraWorker(self.camera,self.int_time)
@@ -134,16 +106,6 @@ class Pixis(QtCore.QThread):
         elif parameter == 'avg_scan':
             self.parameter_dict['avg_scan'] = value
             self.avg_scan = int(value)
-        elif parameter == 'center_wl':
-            cmd = f'{value:0.3f} GOTO'
-            self.write_command(cmd)
-            self.parameter_dict['center_wl'] = value
-            self.center_wl = value
-        elif parameter == 'grating':
-            cmd = f'{value:1.0f} GRATING'
-            self.write_command(cmd)
-            self.parameter_dict['grating'] = value
-            self.grating = value
 
 
     def update_spectrum(self, spec, int_time):
@@ -157,28 +119,32 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array(self.center_wl,self.grating_densities[int(self.grating-1)])
+        return self.calculate_wavelength_array()
 
-    def calculate_wavelength_array(self,center_wavelength_nm,grating_lines_per_mm):
+    def calculate_wavelength_array(self):
         """
         Calculate the wavelength array for a PIXIS camera on SP-2150 spectrograph.
 
         Parameters:
-            center_wavelength_nm: Central wavelength (nm)
-            grating_lines_per_mm: Groove density (lines/mm)
 
         Returns:
             wavelengths: 1D numpy array of wavelengths (nm)
         """
-        calibrated = True
+        if self.monochromator is not None:
+            self.center_wavelength,self.grating_lines_per_mm=self.monochromator.get_monochromator_parameters()
+            pixel_size_mm =self.hardware_params['pixel_size_mm'] 
+            focal_length_mm = self.hardware_params['focal_length_mm']
+            num_pixels = self.hardware_params['num_pixels']
+        
+        calibrated = False
         if calibrated:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             #
 
-            wl_center = center_wavelength_nm
+            wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
@@ -198,11 +164,11 @@ class Pixis(QtCore.QThread):
             wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             # Calculate linear dispersion (nm/mm)
-            dispersion = 1e6 / (focal_length_mm * grating_lines_per_mm)
+            dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
             # Center pixel
             center_pixel = num_pixels // 2
@@ -211,10 +177,20 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = center_wavelength_nm + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
+            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
         return wavelengths
 
+    def attach_to_monochromator(self,monochromator):
+        """
+            Attaches the camera to a monochromator, letting the camera interface know where to get the monochromator parameters from.
+            input:
+                - monochromator (Monochromator QThread): The interface to the monochromator
+        """
+        self.monochromator=monochromator
+        self.type='Spectrometer'
+        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+    
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """
         self.camera.start_acquisition()
@@ -229,6 +205,7 @@ class Pixis(QtCore.QThread):
         """ Gets the intensity. The example include the possibility of averaging several spectra and to
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
+        self.start_acquisition()
         if self.avg_scan == 1:
             while not self.new_spectrum:
                 time.sleep(0.01)
@@ -243,35 +220,12 @@ class Pixis(QtCore.QThread):
                 spectrum = spectrum + self.spectrum
                 self.new_spectrum = False
             spectrum = spectrum / self.avg_scan
+        self.stop_acquisition()
+        spectrum = spectrum[0, :]
         return spectrum
 
     def update_temperature(self,temperature):
         self.parameter_dict['sensor_T'] = temperature
-
-    def write_command(self, cmd):
-        """ Command to write to serial handles timeout by blocking serial commands
-        Args:
-            ser: serial object
-            cmd: write command as defined in PI API
-
-        Returns: read string with only digit content. For troubleshooting, consider printing
-        the entire answer string
-        """
-        cmd_bytes = cmd.encode('ASCII')
-        self.ser.write(cmd_bytes + b"\r")
-        out = bytearray()
-        char = b""
-        missed_char_count = 0
-        while char != b"k":
-            char = self.ser.read()
-            if char == b"":  # handles a timeout here
-                missed_char_count += 1
-                self.serial_busy = True
-                time.sleep(0.1)
-            out += char
-        self.serial_busy = False
-        return re.findall(r'\d+', out.decode().strip())
-
 
 
 class CameraWorker(QtCore.QThread):
@@ -288,7 +242,7 @@ class CameraWorker(QtCore.QThread):
 
         # definition of some parameters
         self.camera = camera
-        self.spec_length = (252,1024)
+        self.spec_length = 1024
         self.change_int_time = False
         self.spectrum = np.zeros(self.spec_length)
         self.int_time = int_time

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -110,7 +110,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
 
-    def get_hardware_parameters(self):
+    def get_hardware_parameters(self, name):
         """
             Returns the hardware parameters of the monochromator
             output:
@@ -125,7 +125,8 @@ class SpectraPro2300i(QtCore.QThread):
                     - curvature
 
         """
-        return self.hardware_params
+        return self.hardware_params[name]
+    
     def get_monochromator_parameters(self):
         """
             Returns the current parameters of the monochromator.
@@ -133,6 +134,4 @@ class SpectraPro2300i(QtCore.QThread):
                 - central_wavelength (np.float): the central wavelength in nm
                 - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
         """
-        return self.center_wl, self.grating_densities[int(self.grating)]
-
-
+        return self.center_wl, self.grating_densities[int(self.grating-1)]

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -1,0 +1,138 @@
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: KatieKoch, Felix Thouin
+"""
+
+import numpy as np
+from PyQt5 import QtCore
+from collections import defaultdict
+import time
+import serial
+import re
+
+class SpectraPro2300i(QtCore.QThread):
+    
+    name = 'SpectraPro2300i'
+    type = 'Monochromator'
+    
+    def __init__(self,hardware_params):
+        super(SpectraPro2300i, self).__init__()
+
+        # set up spectrograph
+        self.serial_busy = False
+        port = 'COM5'
+        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
+                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
+        # get startup values
+        self.grating = float(self.write_command('?GRATING')[0])
+        numbers = self.write_command('?GRATINGS')
+        self.num_gratings = int((len(numbers)-8)/2)
+        self.grating_densities = np.zeros(self.num_gratings)
+        self.grating_blazes = np.zeros(self.num_gratings)
+        for i in range(self.num_gratings):
+            self.grating_densities[i] = numbers[i*3 + 1]
+            self.grating_blazes[i] = numbers[i * 3 + 2]
+        self.center_wl = float(self.write_command('?NM')[0])
+        print(self.center_wl)
+        print(self.grating_densities)
+        print(self.grating_blazes)
+        print(self.grating)
+        print('SP2300 grating info: ', numbers)
+        print('SP2300 grating densities: ',self.grating_densities)
+        print('SP2300 grating blazes: ',self.grating_blazes)
+        print('SP2300 selected grating: ',self.grating)
+
+        # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
+        self.hardware_params=hardware_params
+        # set parameter dict
+        self.parameter_dict = defaultdict()
+        """ Set up the parameter dict. 
+        Here, all properties of parameters to be handled by the parameter dict are defined."""
+        
+        self.parameter_display_dict = defaultdict(dict)
+        
+        self.parameter_dict['central_wave'] = self.center_wl
+        self.parameter_dict['grating'] = self.grating
+        
+        self.parameter_display_dict['central_wave']['val'] = self.center_wl
+        self.parameter_display_dict['central_wave']['unit'] = ' nm'
+        self.parameter_display_dict['central_wave']['min'] = 200.00
+        self.parameter_display_dict['central_wave']['max'] = 1100.00
+        self.parameter_display_dict['central_wave']['read'] = False
+        
+        self.parameter_display_dict['grating']['val'] = self.grating
+        self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['grating']['max'] = 3
+        self.parameter_display_dict['grating']['read'] = False
+
+        # set up parameter dict that only contains value. (faster to access)
+        self.parameter_dict = {}
+        for key in self.parameter_display_dict.keys():
+            self.parameter_dict[key] = self.parameter_display_dict[key]['val']
+    
+    def write_command(self, cmd):
+        """ Command to write to serial handles timeout by blocking serial commands
+        Args:
+            ser: serial object
+            cmd: write command as defined in PI API
+
+        Returns: read string with only digit content. For troubleshooting, consider printing
+        the entire answer string
+        """
+        cmd_bytes = cmd.encode('ASCII')
+        self.ser.write(cmd_bytes + b"\r")
+        out = bytearray()
+        char = b""
+        missed_char_count = 0
+        while char != b"k":
+            char = self.ser.read()
+            if char == b"":  # handles a timeout here
+                missed_char_count += 1
+                self.serial_busy = True
+                time.sleep(0.1)
+            out += char
+        self.serial_busy = False
+        return re.findall(r'\d+', out.decode().strip())
+   
+    def set_parameter(self, parameter, value):
+        """REQUIRED. This function defines how changes in the parameter tree are handled.
+        In devices with workers, a pause of continuous acquisition might be required. """
+        if parameter == 'central_wave':
+            cmd = f'{value:0.3f} GOTO'
+            self.write_command(cmd)
+            self.parameter_dict['center_wave'] = value
+            self.center_wl = value
+        elif parameter == 'grating':
+            cmd = f'{value:1.0f} GRATING'
+            self.write_command(cmd)
+            self.parameter_dict['grating'] = value
+            self.grating = value
+
+    def get_hardware_parameters(self):
+        """
+            Returns the hardware parameters of the monochromator
+            output:
+                - hardware_parameters (dict): A dictionnary of all hardware parameters including:
+                    - f
+                    - delta
+                    - gamma
+                    - n0
+                    - offset_adjust
+                    - d_grating
+                    - x_pixel
+                    - curvature
+
+        """
+        return self.hardware_params
+    def get_monochromator_parameters(self):
+        """
+            Returns the current parameters of the monochromator.
+            output:
+                - central_wavelength (np.float): the central wavelength in nm
+                - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
+        """
+        return self.center_wl, self.grating_densities[int(self.grating)]
+
+

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -35,6 +35,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.grating_densities[i] = numbers[i*3 + 1]
             self.grating_blazes[i] = numbers[i * 3 + 2]
         self.center_wl = float(self.write_command('?NM')[0])
+        self.mirror = float(self.write_command('?MIR')[0])
         print(self.center_wl)
         print(self.grating_densities)
         print(self.grating_blazes)
@@ -55,6 +56,7 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_dict['central_wave'] = self.center_wl
         self.parameter_dict['grating'] = self.grating
+        self.parameter_dict['mirror'] = self.mirror
         
         self.parameter_display_dict['central_wave']['val'] = self.center_wl
         self.parameter_display_dict['central_wave']['unit'] = ' nm'
@@ -64,8 +66,15 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_display_dict['grating']['val'] = self.grating
         self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['mirror']['min'] = 1
         self.parameter_display_dict['grating']['max'] = 3
         self.parameter_display_dict['grating']['read'] = False
+
+        self.parameter_display_dict['mirror']['val'] = self.mirror
+        self.parameter_display_dict['mirror']['unit'] = ' mirror'
+        self.parameter_display_dict['mirror']['min'] = 0
+        self.parameter_display_dict['mirror']['max'] = 1
+        self.parameter_display_dict['mirror']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -109,6 +118,11 @@ class SpectraPro2300i(QtCore.QThread):
             self.write_command(cmd)
             self.parameter_dict['grating'] = value
             self.grating = value
+        elif parameter == 'mirror':
+            cmd = f'{value:1.0f} MIRROR'
+            self.write_command(cmd)
+            self.parameter_dict['mirror'] = value
+            self.mirror = value
 
     def get_hardware_parameters(self, name):
         """

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -28,12 +28,21 @@ class SpectraPro2300i(QtCore.QThread):
         # get startup values
         self.grating = float(self.write_command('?GRATING')[0])
         numbers = self.write_command('?GRATINGS')
-        self.num_gratings = int((len(numbers)-8)/2)
-        self.grating_densities = np.zeros(self.num_gratings)
-        self.grating_blazes = np.zeros(self.num_gratings)
-        for i in range(self.num_gratings):
-            self.grating_densities[i] = numbers[i*3 + 1]
-            self.grating_blazes[i] = numbers[i * 3 + 2]
+        """ Uninstalled turret positions answer with their index and nothing else, so the number of
+        gratings cannot be derived from the length of the reply: (len - 8) / 2 counted 4 on a turret
+        holding 3, and invented a grating of 4 lines/mm. Walk the triples instead and stop at the
+        first implausible groove density. The parsing stays fragile because write_command() keeps
+        only the digits, which also splits a blaze written as "2.0UM" into 2 and 0. """
+        densities, blazes = [], []
+        for i in range(0, len(numbers) - 2, 3):
+            density = float(numbers[i + 1])
+            if density < 50:
+                break
+            densities.append(density)
+            blazes.append(float(numbers[i + 2]))
+        self.num_gratings = len(densities)
+        self.grating_densities = np.array(densities)
+        self.grating_blazes = np.array(blazes)
         self.center_wl = float(self.write_command('?NM')[0])
         self.mirror = float(self.write_command('?MIR')[0])
         print(self.center_wl)
@@ -95,7 +104,15 @@ class SpectraPro2300i(QtCore.QThread):
         out = bytearray()
         char = b""
         missed_char_count = 0
+        """ The loop used to wait for the terminating 'k' of "ok" with no way out: missed_char_count
+        was counted and never acted on, so a controller that stopped answering froze whoever called
+        this, which is the GUI thread. The deadline is generous rather than tight because a turret
+        move answers nothing at all until it has finished. """
+        deadline = time.time() + 60
         while char != b"k":
+            if time.time() > deadline:
+                self.serial_busy = False
+                raise TimeoutError('No reply to %r after 60 s (got %r)' % (cmd, bytes(out)))
             char = self.ser.read()
             if char == b"":  # handles a timeout here
                 missed_char_count += 1
@@ -111,7 +128,7 @@ class SpectraPro2300i(QtCore.QThread):
         if parameter == 'central_wave':
             cmd = f'{value:0.3f} GOTO'
             self.write_command(cmd)
-            self.parameter_dict['center_wave'] = value
+            self.parameter_dict['central_wave'] = value
             self.center_wl = value
         elif parameter == 'grating':
             cmd = f'{value:1.0f} GRATING'
@@ -119,8 +136,13 @@ class SpectraPro2300i(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
         elif parameter == 'mirror':
-            cmd = f'{value:1.0f} MIRROR'
-            self.write_command(cmd)
+            """ The controller ignores "<n> MIRROR": it answers ok and leaves the mirror where it is,
+            so this silently did nothing. The exit mirror is selected with EXIT-MIRROR and then driven
+            with FRONT or SIDE. Checked on the SP-2-300i, serial 23581080: after moving to front,
+            "1 MIRROR" left ?MIRROR reading front, while EXIT-MIRROR followed by SIDE moved it.
+            ?MIR reports 0 for front and 1 for side. """
+            self.write_command('EXIT-MIRROR')
+            self.write_command('SIDE' if int(value) else 'FRONT')
             self.parameter_dict['mirror'] = value
             self.mirror = value
 

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -264,9 +264,13 @@ class StresingCamera(QtCore.QThread):
 
             if self.hardware_params['calibrated']:
 
+                pixel_size_mm = 24 / 1E3  # specs of Sresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of stresing
+
                 wl_center = self.center_wavelength
                 m_order = 1
-                px = np.linspace(1,1024,1024)
+                px = np.linspace(1,1010,1010)
 
                 # calibration from notebook
                 f=self.hardware_params['f']
@@ -280,14 +284,17 @@ class StresingCamera(QtCore.QThread):
 
                 n = px - (n0 + offset_adjust * wl_center)
 
-                # print('psi top', m_order* wl_center)
-                # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
-
                 psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
                 eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
                 self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+
             else:
+
+                pixel_size_mm = 24 / 1E3  # specs of Stresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of Stresing
+
                 # Calculate linear dispersion (nm/mm)
                 dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
@@ -299,8 +306,7 @@ class StresingCamera(QtCore.QThread):
 
                 # Wavelength at each pixel
                 self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-                # Refine the calibration using a mercury spectral lamp
-                self.wavelengths = self.hardware_params['calibrationThirdOrder']*self.wavelengths**2 + self.hardware_params['calibrationSlope']*self.wavelengths + self.hardware_params['calibrationOffset']
+
         else:
             self.wavelengths= self.hardware_params['num_pixels']
             logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength'%datetime.datetime.now())
@@ -313,7 +319,7 @@ class StresingCamera(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
@@ -332,6 +338,7 @@ class StresingCamera(QtCore.QThread):
             time.sleep(0.01)
             self.new_spectrum = False
         self.spec = np.array(self.spectrum[13:-1])
+        self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
         return self.spec
 

--- a/src/main.py
+++ b/src/main.py
@@ -267,29 +267,7 @@ class MainInterface(QtWidgets.QMainWindow):
             item = QtWidgets.QTreeWidgetItem([device.capitalize()])
             self.parameter_tree.addTopLevelItem(item)
             for param in self.parameter_dic[device].keys():
-                child =QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
-                name_widget = QtWidgets.QLabel(param)
-                self.parameter_widgets[param] = QtWidgets.QDoubleSpinBox()
-                #self.parameter_widgets[param].setFixedSize(self.parameter_widgets[param].__sizeof__(), 16)
-                self.parameter_widgets[param].setReadOnly(self.parameter_dic[device][param]['read'])
-                try:
-                    self.parameter_widgets[param].setSuffix(self.parameter_dic[device][param]['unit'])
-                    self.parameter_widgets[param].setMaximum(self.parameter_dic[device][param]['max'])
-                except:
-                    pass
-                try:
-                    self.parameter_widgets[param].setMinimum(self.parameter_dic[device][param]['min'])
-                except:
-                    pass
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    self.parameter_widgets[param].setValue(self.parameter_dic[device][param]['val'])
-                    self.parameter_widgets[param].editingFinished.connect(partial(self.set_parameter,param))
-                    self.writeonly_parameter.append(param)
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, self.parameter_widgets[param])
+                self._build_parameter_tree_item(item, device, param)
 
         # start DataHandling
         # self.spec_length = self.devices['spectrometer'].get_num_pixel()
@@ -440,39 +418,53 @@ class MainInterface(QtWidgets.QMainWindow):
             self.parameter_tree.addTopLevelItem(item)
 
             for param in self.parameter_dic[device].keys():
-                child = QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
+                self._build_parameter_tree_item(item, device, param)
 
-                name_widget = QtWidgets.QLabel(param)
-                spin = QtWidgets.QDoubleSpinBox()
-                self.parameter_widgets[param] = spin
+    def _build_parameter_tree_item(self, item, device, param):
+        '''
+            Builds one row of the parameter tree (name label + value spinbox) for a
+            single device parameter and registers the resulting widget in
+            self.parameter_widgets/readonly_parameter/writeonly_parameter.
+            Cryostat parameters are always shown read-only here regardless of the
+            driver's 'read' flag: control of the cryostat must go through the
+            dedicated CryostatTab page. This tree only displays/logs its value.
+        '''
+        child = QtWidgets.QTreeWidgetItem()
+        item.addChild(child)
 
-                spin.setReadOnly(self.parameter_dic[device][param]['read'])
+        name_widget = QtWidgets.QLabel(param)
+        spin = QtWidgets.QDoubleSpinBox()
+        self.parameter_widgets[param] = spin
 
-                try:
-                    spin.setSuffix(self.parameter_dic[device][param]['unit'])
-                    spin.setMaximum(self.parameter_dic[device][param]['max'])
-                except Exception:
-                    pass
+        param_info = self.parameter_dic[device][param]
+        force_read_only = (device == 'cryostat')
+        spin.setReadOnly(param_info['read'] or force_read_only)
 
-                try:
-                    spin.setMinimum(self.parameter_dic[device][param]['min'])
-                except Exception:
-                    pass
+        try:
+            spin.setSuffix(param_info['unit'])
+            spin.setMaximum(param_info['max'])
+        except Exception:
+            pass
 
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    spin.setValue(self.parameter_dic[device][param]['val'])
-                    spin.editingFinished.connect(
-                        partial(self.set_parameter, param)
-                    )
-                    self.writeonly_parameter.append(param)
+        try:
+            spin.setMinimum(param_info['min'])
+        except Exception:
+            pass
 
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, spin)
+        if param_info['read']:
+            self.readonly_parameter.append(param)
+        elif force_read_only:
+            spin.setValue(param_info['val'])
+            self.readonly_parameter.append(param)
+        else:
+            spin.setValue(param_info['val'])
+            spin.editingFinished.connect(partial(self.set_parameter, param))
+            self.writeonly_parameter.append(param)
 
-    
+        self.parameter_tree.setItemWidget(child, 0, name_widget)
+        self.parameter_tree.setItemWidget(child, 1, spin)
+
+
 
     def update_read_parameter(self, new_parameter):
         for param in new_parameter.keys():

--- a/src/main.py
+++ b/src/main.py
@@ -393,6 +393,16 @@ class MainInterface(QtWidgets.QMainWindow):
         # Rebuild parameter tree UI (existing code)
         self.create_parameter_array()
 
+        self.parameter = {}
+        for device in self.parameter_dic:
+            for param in self.parameter_dic[device]:
+                self.parameter[param] = self.parameter_dic[device][param]['val']
+        self.DataHandling.close()
+        self.DataHandling = DataHandling(self.parameter, self.spec_length)
+        self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
+        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
+        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+
         logger.info(
             f"Switched to spectrometer: {new_name} "
             f"(spec_length={self.spec_length})"

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -564,13 +564,60 @@ class FitTemporalBeamCalibration(QtCore.QThread):
         # Loop through each wavelength 
         max_chirp_values = []
         wavelength_values = []
-        for wls in range(self.data.shape[1]):
-            intensity_column = self.data[:, wls]
-            max_row_index = np.argmax(intensity_column)
-            if max_row_index == 0:
-                continue
-            max_chirp_values.append(self.chirp_array[max_row_index])
-            wavelength_values.append(self.wavelength_array[wls])
+        # for wls in range(self.data.shape[1]):
+        #     intensity_column = self.data[:, wls]
+        #     max_row_index = np.argmax(intensity_column)
+        #     if max_row_index == 0:
+        #         continue
+        #     max_chirp_values.append(self.chirp_array[max_row_index])
+        #     wavelength_values.append(self.wavelength_array[wls])
+
+
+        # ----- Find starting wavelength -----
+        # wavelength with the strongest overall signal
+        start_col = np.argmax(np.max(self.data, axis=0))
+
+        # maximum there
+        start_row = np.argmax(self.data[:, start_col])
+
+        indices = np.zeros(self.data.shape[1], dtype=int)
+        indices[start_col] = start_row
+
+        # Search window in chirp units
+        window = 1000   # fs²/rad²
+
+        dchirp = np.abs(self.chirp_array[1] - self.chirp_array[0])
+        N = int(window / dchirp)
+
+        # ---------- Track toward longer wavelengths ----------
+        for col in range(start_col + 1, self.data.shape[1]):
+
+            prev = indices[col-1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # ---------- Track toward shorter wavelengths ----------
+        for col in range(start_col-1, -1, -1):
+
+            prev = indices[col+1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # Final arrays
+        max_chirp_values = self.chirp_array[indices]
+        wavelength_values = self.wavelength_array
+
+
         max_chirp_values = np.array(max_chirp_values)
         wavelength_values = np.array(wavelength_values)
         omega_values = 0.5*co.waveToAngFreq(np.array(wavelength_values) * 1e-9) # rad Hz

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -85,7 +85,7 @@ class VerticalBeamCalibrationMeasurement(QtCore.QThread):
                 self.vertical_calibration_data['intensities']=self.intensities
                 self.vertical_calibration_data['rows']=self.rows
                 if i>=1:
-                    self.send_intensities.emit(self.rows,self.intensities[1:])
+                    self.send_intensities.emit(self.rows,self.intensities)
         self.vertical_calibration_data['intensities']=self.intensities
         self.vertical_calibration_data['rows']=self.rows
         self.send_vertical_calibration_data.emit(('vertical_calibration_data',self.vertical_calibration_data))
@@ -423,11 +423,12 @@ class ChirpCalibrationMeasurement(QtCore.QThread):
                                 'data' : np.array(self.intensities)
                                 }
                             if i>=3:
-                                indexes = np.where(
-                                    (self.wls >= (self.carrierWls/2 - 100)) &
-                                    (self.wls <= (self.carrierWls/2 + 100))
-                                )[0]
-                                self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                # indexes = np.where(
+                                #     (self.wls >= (self.carrierWls/2 - 100)) &
+                                #     (self.wls <= (self.carrierWls/2 + 100))
+                                # )[0]
+                                # self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                self.send_chirp.emit(self.chirp[3:i],self.wls,np.array(self.intensities)[3:i,:])
         self.send_chirp_calibration_data.emit(('chirp_calibration_raw_data',self.Chirp_calibration_data))
         self.sendProgress.emit(100)
         self.stop()
@@ -775,6 +776,7 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         data_filtered_region = data_filtered[1:-1, mask]
         data_integrated = np.sum(data_filtered_region, axis=1)
         data_integrated_normalized = data_integrated/np.max(data_integrated)
+        data_integrated_normalized = -(data_integrated_normalized-np.max(data_integrated_normalized))
 
         self.sendCrossCorrelationRegion.emit(delay_array_region, data_integrated_normalized)
         self.delay_calibration_processed_data={
@@ -799,7 +801,8 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         C0 = np.min(self.intensity)
 
         p0 = [A0, mu0, sigma0, C0]
-        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0)
+        bounds = ([-np.inf, self.delay.min(), 0, -np.inf], [ np.inf, self.delay.max(), np.inf, np.inf])
+        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0, bounds=bounds)
         A, mu, sigma, C = popt
         self.fitted_intensity = (A * np.exp(-(self.delay - mu)**2 / (2 * sigma**2)) + C)
         self.sendCrossCorrelationRegionFit.emit(self.delay, self.fitted_intensity, mu, sigma)

--- a/src/measurements/MDCSClasses.py
+++ b/src/measurements/MDCSClasses.py
@@ -191,20 +191,20 @@ class BoxcarGeometry(QtCore.QThread):
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
                 'C' : self.t_secondary[i]*np.ones(Nb_step),
-                'B' : self.t_scanned,
+                'B' : self.t_scanned.copy(),
                 'LO' : self.t_scanned-self.t_LO*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - rephasing':
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
-                'C' : self.t_scanned,
+                'C' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - non rephasing':
             self.group_delay = {
                 'C' : np.zeros(Nb_step),
-                'A' : self.t_scanned,
+                'A' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
@@ -215,6 +215,17 @@ class BoxcarGeometry(QtCore.QThread):
                 'A' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
+        elif self.measurement_type == 'LO scan':
+            self.group_delay = {
+                'C' : np.zeros(Nb_step),
+                'B' : np.zeros(Nb_step),
+                'A' : np.zeros(Nb_step),
+                'LO' : self.t_scanned.copy()
+            }
+        
+        # To give the right delay between pulse
+        for key in self.group_delay:
+            self.group_delay[key] *= -1
 
     def phase_cycling(self, j):
         '''


### PR DESCRIPTION
## Summary
Three SpectraPro2300i bugs found while testing: the exit mirror command never actually moved the mirror (wrong serial command), the grating count was miscounted (reported 4 instead of 3), and `write_command()` had no timeout so a non-responding controller froze the GUI thread. Also fixes a `center_wave`/`central_wave` typo.

## Test plan
- Verified against the physical instrument (SP-2-300i, serial 23581080).