### PR TITLE
Fix/stresing acquisition reliability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Binary files must never go through line-ending conversion. Committing the debugging report as a
+# PDF made git warn that LF would be replaced by CRLF, which would corrupt the file on checkout.
+*.pdf binary
+*.h5 binary
+*.dll binary
+*.png binary
+*.jpg binary
+*.stl binary
+*.lut binary

--- a/manual/camera_spectrometer.md
+++ b/manual/camera_spectrometer.md
@@ -1,0 +1,5 @@
+# Camera and spectrometer
+
+Colbert can be used with two cameras (Stresing and Pixis) plugged to one spoectrometer. Everything is managed in the intruments.py where you can add or removed devices. The spectrometer is the main device where the cameras could be attached, meaning that all camera parameters are child of the parent spectrometer. Those parameters are all saved and managed through Data Handling. 
+
+On the main panel, on the top right, you can find a sliding menu where there is a list of the connected cameras. Selecting another camera reset completely Data Handling beacause the number of parameter is changing between cameras and also the length of the sensor may be different. For those reasons, it is easier to reset. All the other calibrations that were not associated with the camera will be loaded back. However, the connection between the beam explorer and Data Handling seems to be lost. 

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -49,14 +49,19 @@ class DataHandling(QtCore.QThread):
         self.parameter_measured = np.zeros([len(self.parameter) + 2, 0])
 
         # preallocate data arrays depending on data dimension (1D or 2D).
+        """ The background is zeroed, not np.empty: an np.empty array holds whatever was in memory,
+        and subtracting it corrupts every spectrum silently. has_background says whether a real
+        background was ever measured or loaded; until then correct_background subtracts nothing. """
         if self.data_dim  == 1:
             self.spec = np.empty([self.speclength, 0])
-            self.background = np.empty([self.speclength, 1])
+            self.background = np.zeros([self.speclength, 1])
             self.wls = np.empty([self.speclength, 1])
         else:
             self.spec = np.empty([0,self.speclength[0],self.speclength[1]])
-            self.background = np.empty([0,self.speclength[0],self.speclength[1]])
+            self.background = np.zeros([1,self.speclength[0],self.speclength[1]])
             self.wls = np.empty([self.speclength[1], 1])
+        self.has_background = False
+        self.background_warned = False
 
         # set initial values
         self.maximum = np.zeros([3])
@@ -123,7 +128,7 @@ class DataHandling(QtCore.QThread):
         self.wls = wls
         if self.data_dim == 1:
             if self.correct_background:
-                spec = spec - self.background.ravel()
+                spec = self.subtract_background(spec)
             self.spec = np.c_[self.spec, spec]
 
         else:
@@ -155,6 +160,65 @@ class DataHandling(QtCore.QThread):
             self.maximum[2] = wls[np.unravel_index(spec.argmax(), spec.shape)[1]]
         self.maximum[0] = curr_time
         self.sendMaximum.emit(self.maximum)
+
+    def subtract_background(self, spec):
+        """
+            Subtracts the stored background, and refuses to do anything else.
+            Returns the spectrum unchanged, with one warning, when no background has been measured or
+            loaded, or when the stored one does not match the current spectrum length. Both used to go
+            through unnoticed: the background array was allocated with np.empty and no measurement ever
+            filled it, so ticking background correction subtracted uninitialised memory.
+            input:
+                - spec (np.ndarray): spectrum to correct
+            output:
+                - np.ndarray: corrected spectrum, or the original one if no valid background
+        """
+        reason = None
+        if not self.has_background:
+            reason = 'no background has been acquired or loaded'
+        elif self.background.size != np.size(spec):
+            reason = ('background is %d points, spectrum is %d'
+                      % (self.background.size, np.size(spec)))
+        if reason is not None:
+            if not self.background_warned:
+                logger.warning('%s Background correction is on but was not applied: %s'
+                               % (datetime.datetime.now(), reason))
+                self.background_warned = True
+            return spec
+        return spec - self.background.ravel()
+
+    def use_background(self, spec):
+        """
+            Adopts a spectrum as the background to subtract.
+            input:
+                - spec (np.ndarray): background spectrum. A file holding several spectra is accepted,
+                  in which case the last one is used, matching how load_bg used to slice it.
+            output:
+                - bool: whether a usable background was stored
+        """
+        flat = np.asarray(spec, dtype=float).ravel()
+        if self.data_dim == 1 and flat.size != self.speclength:
+            if self.speclength and flat.size % self.speclength == 0:
+                flat = flat[-self.speclength:]
+            else:
+                logger.error('%s Background rejected: %d points for a %s point spectrum'
+                             % (datetime.datetime.now(), flat.size, self.speclength))
+                return False
+        self.background = flat.reshape(-1, 1) if self.data_dim == 1 else np.asarray(spec, dtype=float)
+        self.has_background = True
+        self.background_warned = False
+        logger.info('%s Background stored (%d points)' % (datetime.datetime.now(), flat.size))
+        return True
+
+    @QtCore.pyqtSlot(np.ndarray, np.ndarray)
+    def set_background(self, wls, spec):
+        """
+            Slot for a background measurement, which emits wavelengths and intensities together.
+            input:
+                - wls (np.ndarray): wavelengths, unused
+                - spec (np.ndarray): measured background
+        """
+        self.use_background(spec)
 
     # save data to temp file and clear data in memory
     def save_buffer(self):
@@ -334,14 +398,21 @@ class DataHandling(QtCore.QThread):
         # preallocate data arrays depending on data dimension (1D or 2D).
         if self.data_dim == 1:
             self.spec = np.empty([self.speclength, 0])
-
-            self.background = np.empty([self.speclength, 1])
+            self.background = np.zeros([self.speclength, 1])
             self.wls = np.empty([self.speclength, 1])
         else:
             self.spec = np.empty([0, self.speclength[0], self.speclength[1]])
-
-            self.background = np.empty([0, self.speclength[0], self.speclength[1]])
+            self.background = np.zeros([1, self.speclength[0], self.speclength[1]])
             self.wls = np.empty([self.speclength[1], 1])
+
+        """ A background belongs to the spectrometer it was taken on, so changing spectrometer drops
+        it. It used to be reallocated with np.empty while the correction checkbox stayed ticked,
+        which silently turned a valid background into uninitialised memory. """
+        if self.has_background:
+            logger.warning('%s Background dropped: the spectrum length changed to %s'
+                           % (datetime.datetime.now(), self.speclength))
+        self.has_background = False
+        self.background_warned = False
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -128,8 +128,15 @@ class DataHandling(QtCore.QThread):
 
         else:
             self.spec = np.concatenate([self.spec, spec[np.newaxis, ...]])
+        """ A parameter only has a recorded value once update_parameter() has run for it. Reading
+        queue[-1] unconditionally raised IndexError on every spectrum, which killed this slot before
+        sendSpectrum was emitted: the measurement finished, the traceback went to stderr rather than
+        to the log, and no spectrum ever reached the plot. Parameters with nothing recorded keep
+        their previous value instead. """
         for idx, param in enumerate(self.parameter_queue.keys()):
-            self.param_from_deque[idx] = self.parameter_queue[param][-1]
+            queue = self.parameter_queue[param]
+            if queue:
+                self.param_from_deque[idx] = queue[-1]
         self.parameter_measured = np.c_[self.parameter_measured, self.param_from_deque]
         self.parameter_measured[0, -1] = curr_time
         self.parameter_measured[1, -1] = time.time()

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -14,6 +14,7 @@ import numpy as np
 import os.path
 from collections import deque
 import shutil
+import threading
 import logging
 import datetime
 from numpy.polynomial import Polynomial as P
@@ -80,8 +81,12 @@ class DataHandling(QtCore.QThread):
         self.calibration = {}
 
         # initialize BufferWorker
+        """ The worker writes the buffer in its own thread. save_data() has to know when that write
+        has actually finished before it copies the file, so the worker signals completion through
+        this event. It used to sleep 0.5 s and hope. """
+        self.buffer_written = threading.Event()
         self.thread = QtCore.QThread()
-        self.BufferWorker = BufferWorker(self.temp_filename,self.data_dim)
+        self.BufferWorker = BufferWorker(self.temp_filename, self.data_dim, self.buffer_written)
         self.BufferWorker.moveToThread(self.thread)
         self.thread.start()
         self.bufferSaveSignal.connect(self.BufferWorker.save_buffer)
@@ -93,15 +98,27 @@ class DataHandling(QtCore.QThread):
         """ This is an important part of hardware parameter control. We use "deque" as efficient First-In-First-Out
         Queues that allow to have a continuous acces to the last 100.000 hardware parameters. Each parameter has their
         on deque object. Each time the update parameter function is called by the updater, the most updated value of the
-        hardware parameter is added to the deque"""
+        hardware parameter is added to the deque.
+            input:
+                - parameter (dict): parameter name -> current value. Names absent from the dictionary,
+                  and values that are not numbers such as the cryostat reporting "Stable", repeat the
+                  last recorded value so the columns stay aligned with the spectra.
+
+        This used to take a sequence indexed positionally, and nothing in the code ever called it.
+        The queues therefore stayed empty, which left parameter_measured full of zeros: no hardware
+        setting was ever stored beside the data it belongs to.
+        """
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
 
-        for idx, param in enumerate(self.parameter):
-            self.parameter_queue[param].append(parameter[idx])
+        for param in self.parameter:
+            queue = self.parameter_queue[param]
+            try:
+                value = float(parameter[param])
+            except (KeyError, TypeError, ValueError):
+                value = queue[-1] if queue else 0.0
+            queue.append(value)
 
-        # for param, value in zip(self.parameter_queue, parameter):
-        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -225,6 +242,7 @@ class DataHandling(QtCore.QThread):
         """ Saves data to a temporary file and populates it each time more than 100 spectra have been acquired.
         If the file is created, some attributes such as yaxis and parameter keys are added."""
         t1 = time.time()
+        self.buffer_written.clear()
         self.bufferSaveSignal.emit(self.spec, self.wls, self.parameter_queue, self.parameter_measured)
 
         # clear arrays in memory
@@ -253,7 +271,13 @@ class DataHandling(QtCore.QThread):
     def save_data(self, filename, comments):
         """saves data. Each time data is saved, parameters are saved aswell. """
         self.save_buffer()
-        time.sleep(0.5) # allow for BufferWorker to create temp file
+        """ Wait for the worker to finish writing rather than sleeping a fixed 0.5 s: on a large
+        buffer or a slow disk that sleep expired first and the file below was copied half written.
+        The timeout is long because it only has to cover a genuinely slow write. """
+        if not self.buffer_written.wait(timeout=60):
+            logger.error('%s Not saved: the buffer was still being written after 60 s'
+                         % datetime.datetime.now())
+            return
         with h5py.File(self.temp_filename, 'a') as hf:
             hf.attrs["comments"] = comments
             if len(self.calibration) > 0 :
@@ -463,10 +487,11 @@ class BufferWorker(QtCore.QObject):
     """ Buffer worker saves data to a temp file.
     It is started every time a given amount of data has been acquired and receives signals with the corresponding data"""
 
-    def __init__(self,temp_filename, data_dim):
+    def __init__(self, temp_filename, data_dim, done_event=None):
         super(BufferWorker, self).__init__()
         self.temp_filename = temp_filename
         self.data_dim = data_dim
+        self.done_event = done_event
         self.firstbuffer = True
         self.terminate = False
         # check if folder for buffer exists
@@ -511,3 +536,7 @@ class BufferWorker(QtCore.QObject):
                     hf["parameter"][:, -parameter_measured.shape[1]:] = parameter_measured
             except TypeError:
                 logger.warning('% s Saving failed. Did you already save?' %datetime.datetime.now())
+        """ Release save_data(). Left unset if the write above raised, so save_data() times out and
+        refuses to copy rather than copying a half-written file. """
+        if self.done_event is not None:
+            self.done_event.set()

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -91,8 +91,12 @@ class DataHandling(QtCore.QThread):
         hardware parameter is added to the deque"""
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
+
         for idx, param in enumerate(self.parameter):
             self.parameter_queue[param].append(parameter[idx])
+
+        # for param, value in zip(self.parameter_queue, parameter):
+        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -308,7 +312,10 @@ class DataHandling(QtCore.QThread):
         Parameters:
             new_length (int): The new number of pixels in the spectrum.
         """
-        self.speclength = new_length
+        if isinstance(new_length, tuple):
+            self.speclength = new_length[1]  # or [0], whichever is intended
+        else:
+            self.speclength = new_length
 
         # Reset spectrum buffer
         self.spec = np.zeros((self.speclength, 0))  # zero columns, rows = new_length
@@ -331,6 +338,47 @@ class DataHandling(QtCore.QThread):
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")
+
+    def close(self):
+        """Safely stop Qt thread + worker before re-instantiating DataHandling."""
+
+        # 1. Stop worker thread safely (if it has a stop flag)
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.terminate = True  # your custom flag (optional)
+        except:
+            pass
+
+        # 2. Disconnect signals (VERY important)
+        try:
+            if hasattr(self, "bufferSaveSignal"):
+                self.bufferSaveSignal.disconnect()
+        except:
+            pass
+
+        # 3. Quit Qt thread event loop
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.quit()
+                self.thread.wait()   # blocks until fully stopped
+        except:
+            pass
+
+        # 4. Delete worker safely
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.deleteLater()
+                self.BufferWorker = None
+        except:
+            pass
+
+        # 5. Delete thread safely
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.deleteLater()
+                self.thread = None
+        except:
+            pass
 
 
 class BufferWorker(QtCore.QObject):

--- a/src/GUI/BeamExplorer.py
+++ b/src/GUI/BeamExplorer.py
@@ -188,7 +188,7 @@ class BeamWidget(QWidget):
 
     def set_phase_manually(self):
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
     def toggle_beam_to_slm(self):
         '''
@@ -217,7 +217,7 @@ class BeamWidget(QWidget):
         self.beam.set_beamVerticalDelimiters([int(self.delimiter_table.item(0,0).text()),int(self.delimiter_table.item(0,1).text())])
         self.beam.set_beamHorizontalDelimiters([int(self.delimiter_table.item(1,0).text()),int(self.delimiter_table.item(1,1).text())])
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
         return self.name,self.beam
 

--- a/src/GUI/SpectrometerPlot.py
+++ b/src/GUI/SpectrometerPlot.py
@@ -30,15 +30,10 @@ class SpectrometerPlot(QtWidgets.QMainWindow):
         # add firstplot for Acquire mode
         self.first_plot = True
 
-        # create random example data set
-        sigma = 40
-        mu = 2
-        wls = np.array(np.linspace(177.2218, 884.00732139, 512))
-        spec = np.random.randint(0, 100, 512) + 20000./ (sigma * np.sqrt(2. * np.pi)) * np.exp(- (wls - mu - 620.) ** 2. / (2. * sigma ** 2.)) - 50,
-        flatspec = np.array(spec)
-
-        # plot data: x, y values
-        self.graphWidget.plot(wls.reshape(-1), flatspec.reshape(-1),pen =pg.mkPen([200,200,200], width = 2))
+        """ The plot starts empty. It used to be seeded with a random gaussian spanning 177 to 884 nm,
+        which stayed on the plot and stretched the axes over that whole range: a real spectrum from
+        the Stresing covers about 48 nm, so it was squeezed into a narrow strip and read as nothing
+        being displayed. """
         self.graphWidget.getAxis('left').setStyle(tickFont = fontForTickValues)
         self.graphWidget.getAxis('bottom').setStyle(tickFont = fontForTickValues)
         self.graphWidget.setLabel('left', 'Intensity (counts)', **styles)

--- a/src/GUI/main_GUI.ui
+++ b/src/GUI/main_GUI.ui
@@ -2716,6 +2716,11 @@ p, li { white-space: pre-wrap; }
              <string>2Q</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>LO scan</string>
+            </property>
+           </item>
           </widget>
           <widget class="QLabel" name="Measurement_TLO_delay_label">
            <property name="geometry">

--- a/src/compute/beams.py
+++ b/src/compute/beams.py
@@ -481,10 +481,6 @@ class Beam:
         elif TaylorPrefactorFlag == 'remove':
             coef = [c / f for c, f in zip(coef, TaylorFactor)]
 
-        # Add minus sign to the group delay (linear term)
-        if len(coef) > 1:
-            coef[1] *= -1
-
         return P(coef)
     
     @staticmethod

--- a/src/drivers/CryoDemo.py
+++ b/src/drivers/CryoDemo.py
@@ -3,11 +3,11 @@
 Created on Thu Sep  1 13:26:53 2022
 
 @author: NanoUltrafast2
-Hardware class to controll cryostat. All hardware classes require a definition of
-parameter_dict (set write and read parameter)
-parameter_display_dict (set Spinbox options)
-set_parameter function (assign set functions)
-
+Simulated cryostat driver used when no CryoPasqal hardware is available.
+Mirrors the parameter names (drivers.Optidry250.CryoPasqal.parameter_display_dict)
+and the command methods used by GUI.cryostattab.CryostatTab, so the dedicated
+cryostat page and the generic parameter tree behave the same way in demo mode
+as they do with real hardware.
 """
 
 import numpy as np
@@ -19,94 +19,203 @@ from collections import defaultdict
 class CryoDemo(QtCore.QThread):
 
     name = 'CryoDemo'
-    type = 'Cryostatas'
-    
+    type = 'Cryostat'
+
     def __init__(self):
         super(CryoDemo, self).__init__()
 
-
-        # set parameter dict
-        self.parameter_dict = defaultdict()
-        
-        # setting up variables, open array
-        self.set_T = []
-        self.current_T = []
-        self.stop = False
         self.parameter_display_dict = defaultdict(dict)
-        self.parameter_display_dict['set_T']['val'] = 5
-        self.parameter_display_dict['set_T']['unit'] = ' K'
-        self.parameter_display_dict['set_T']['max'] = 1000
-        self.parameter_display_dict['set_T']['read'] = False
-        self.parameter_display_dict['current_T']['val'] = 5
-        self.parameter_display_dict['current_T']['unit'] = ' K'
-        self.parameter_display_dict['current_T']['max'] = 1000
-        self.parameter_display_dict['current_T']['read'] = True
+
+        # --- Setpoint and Loop settings ---
+        self.parameter_display_dict['Set_T']['val'] = 5.0
+        self.parameter_display_dict['Set_T']['unit'] = ' K'
+        self.parameter_display_dict['Set_T']['min'] = 0
+        self.parameter_display_dict['Set_T']['max'] = 400
+        self.parameter_display_dict['Set_T']['read'] = False
+
+        self.parameter_display_dict['Regulation_Loop']['val'] = 1
+        self.parameter_display_dict['Regulation_Loop']['unit'] = ' loop'
+        self.parameter_display_dict['Regulation_Loop']['min'] = 1
+        self.parameter_display_dict['Regulation_Loop']['max'] = 2
+        self.parameter_display_dict['Regulation_Loop']['read'] = False
+
+        # --- Temperatures (Channels A to E) ---
+        for channel in ['ChannelA_T', 'ChannelB_T', 'ChannelC_T', 'ChannelD_T', 'ChannelE_T']:
+            self.parameter_display_dict[channel]['val'] = 5.0
+            self.parameter_display_dict[channel]['unit'] = ' K'
+            self.parameter_display_dict[channel]['min'] = 0
+            self.parameter_display_dict[channel]['max'] = 400
+            self.parameter_display_dict[channel]['read'] = True
+
+        # --- Pressures (Channels F and G) ---
+        self.parameter_display_dict['PressureF']['val'] = 101300.0
+        self.parameter_display_dict['PressureF']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureF']['min'] = 0
+        self.parameter_display_dict['PressureF']['max'] = 200000
+        self.parameter_display_dict['PressureF']['read'] = True
+
+        self.parameter_display_dict['PressureG']['val'] = 101300.0
+        self.parameter_display_dict['PressureG']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureG']['min'] = 0
+        self.parameter_display_dict['PressureG']['max'] = 200000
+        self.parameter_display_dict['PressureG']['read'] = True
+
+        # --- PID Parameters ---
+        self.parameter_display_dict['Pid_P']['val'] = 0.0
+        self.parameter_display_dict['Pid_P']['unit'] = ' P'
+        self.parameter_display_dict['Pid_P']['min'] = 0
+        self.parameter_display_dict['Pid_P']['max'] = 1000
+        self.parameter_display_dict['Pid_P']['read'] = False
+
+        self.parameter_display_dict['Pid_I']['val'] = 0.0
+        self.parameter_display_dict['Pid_I']['unit'] = ' I'
+        self.parameter_display_dict['Pid_I']['min'] = 0
+        self.parameter_display_dict['Pid_I']['max'] = 1000
+        self.parameter_display_dict['Pid_I']['read'] = False
+
+        self.parameter_display_dict['Pid_D']['val'] = 0.0
+        self.parameter_display_dict['Pid_D']['unit'] = ' D'
+        self.parameter_display_dict['Pid_D']['min'] = 0
+        self.parameter_display_dict['Pid_D']['max'] = 1000
+        self.parameter_display_dict['Pid_D']['read'] = False
+
+        # --- Status and Compressor ---
+        self.parameter_display_dict['OnOff_comp']['val'] = 0
+        self.parameter_display_dict['OnOff_comp']['unit'] = ' state'
+        self.parameter_display_dict['OnOff_comp']['min'] = 0
+        self.parameter_display_dict['OnOff_comp']['max'] = 1
+        self.parameter_display_dict['OnOff_comp']['read'] = False
+
+        self.parameter_display_dict['Stability']['val'] = "In progress"
+        self.parameter_display_dict['Stability']['unit'] = ''
+        self.parameter_display_dict['Stability']['read'] = True
+
+        self.parameter_display_dict['Critical_State']['val'] = "OK"
+        self.parameter_display_dict['Critical_State']['unit'] = ''
+        self.parameter_display_dict['Critical_State']['read'] = True
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
         for key in self.parameter_display_dict.keys():
             self.parameter_dict[key] = self.parameter_display_dict[key]['val']
 
+        # --- History for stability calculation ---
+        self.temp_history = []
+        self.stability_threshold = 0.05
+        self.stability_window = 30
 
-        
-        # defining waitTime
-        self.waitTime = 0.1
-
-        # start updating temp
-        self.UpdateWorker = UpdateWorker()
-        self.UpdateWorker.new_T.connect(self.update_temp)
+        # start simulated background polling worker
+        self.UpdateWorker = DemoWorker(self.parameter_dict['ChannelA_T'], self.parameter_dict['Set_T'])
+        self.UpdateWorker.new_T.connect(self.update_all_data)
         self.UpdateWorker.start()
 
-    def set_parameter(self,parameter,value):
-        if parameter == 'set_T':
-            self.update_set_T(value)
+    def set_parameter(self, parameter, value):
+        """Called by the generic parameter tree (banderole) for writable params."""
+        self.parameter_dict[parameter] = value
+        if parameter in self.parameter_display_dict:
+            self.parameter_display_dict[parameter]['val'] = value
+
+        if parameter == 'Set_T':
             self.UpdateWorker.target = value
+        elif parameter == 'OnOff_comp':
+            self.set_compressor_state(bool(int(value)))
 
-    def update_set_T(self, set_temperature):
-        #set temperature to some degree K
-        #requests.put("http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature",json = {"platformTargetTemperature": set_temperature})
-        
-        print(f'Temperature set to {set_temperature}')
-              
-    def start_cool(self):
-        #start chamber cooldown
-        #requests.post('http://10.131.3.6:47101/v1/controller/methods/cooldown()')
-        
-        print("Cooldown has started")
-        
-    def start_warm(self):
-        # warmup the chamber
-        # requests.post('http://10.131.3.6:47101/v1/controller/methods/warmup()')
-        print("Warming Up")
-        
-    def update_temp(self, new_T):
-        self.parameter_dict['current_T'] = new_T
+    # --- Simulated hardware commands, mirror CryoPasqal's API used by CryostatTab ---
+
+    def set_temperature_setpoint(self, loop, target_temp):
+        self.parameter_dict['Set_T'] = target_temp
+        self.parameter_display_dict['Set_T']['val'] = target_temp
+        self.UpdateWorker.target = target_temp
+        print(f'[Demo] Loop {loop} setpoint updated to: {target_temp} K')
+
+    def set_heater_range(self, loop, range_level):
+        print(f'[Demo] Loop {loop} Heater Range updated to: {range_level}')
+
+    def set_pid_parameters(self, loop, p, i, d):
+        self.parameter_dict['Pid_P'] = p
+        self.parameter_dict['Pid_I'] = i
+        self.parameter_dict['Pid_D'] = d
+        print(f'[Demo] Loop {loop} PID parameters updated: P={p}, I={i}, D={d}')
+
+    def set_compressor_state(self, state_on):
+        self.parameter_dict['OnOff_comp'] = int(bool(state_on))
+        self.parameter_display_dict['OnOff_comp']['val'] = int(bool(state_on))
+        self.UpdateWorker.compressor_on = bool(state_on)
+        print(f"[Demo] Compressor set to: {'ON' if state_on else 'OFF'}")
+
+    def reset_compressor_alarm(self):
+        self.parameter_dict['Critical_State'] = 'OK'
+        self.parameter_display_dict['Critical_State']['val'] = 'OK'
+        print('[Demo] Alarm reset command sent.')
+
+    def update_all_data(self, data_list):
+        """Slot receiving simulated sensor data from the background worker."""
+        def assign_val(key, val):
+            self.parameter_dict[key] = val
+            self.parameter_display_dict[key]['val'] = val
+
+        assign_val('ChannelA_T', data_list[0])
+        assign_val('ChannelB_T', data_list[1])
+        assign_val('ChannelC_T', data_list[2])
+        assign_val('ChannelD_T', data_list[3])
+        assign_val('ChannelE_T', data_list[4])
+        assign_val('PressureF', data_list[5])
+        assign_val('PressureG', data_list[6])
+
+        self.calculate_stability(data_list[0])
+
+    def calculate_stability(self, current_temp):
+        self.temp_history.append(current_temp)
+        if len(self.temp_history) > self.stability_window:
+            self.temp_history.pop(0)
+
+        status = "In progress"
+        if len(self.temp_history) >= self.stability_window:
+            temp_range = max(self.temp_history) - min(self.temp_history)
+            if temp_range <= self.stability_threshold:
+                status = "Stable"
+
+        self.parameter_dict['Stability'] = status
+        self.parameter_display_dict['Stability']['val'] = status
 
 
+class DemoWorker(QtCore.QThread):
+    """Background worker that simulates the cryostat drifting toward its setpoint."""
 
-class UpdateWorker(QtCore.QThread):
+    new_T = QtCore.pyqtSignal(list)
 
-    new_T = QtCore.pyqtSignal(float)
-
-    def __init__(self):
-        super(UpdateWorker, self).__init__()
-        self.currentT = []
+    def __init__(self, initial_temp, initial_target):
+        super(DemoWorker, self).__init__()
         self.stop = False
-        self.waitTime = 0.1
-        self.target = 300
+        self.waitTime = 0.5
+        self.target = initial_target
+        self.current_T = initial_temp
+        self.compressor_on = False
+        self.cooling_rate = 0.5  # K per tick toward target when compressor is on
 
     def run(self):
         while not self.stop:
-            # calling the read temperature function
-            self.readtemp = self.read_T()
-
-            # waiting to remeasure the temperature
+            self.new_T.emit(self.simulate_step())
             time.sleep(self.waitTime)
-            self.new_T.emit(self.readtemp)
 
-    def read_T(self):
-        #read the current platform target temperature
-        #resp=requests.get('http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature')
-        target = self.target + np.random.rand(1)
-        return target
+    def simulate_step(self):
+        # Drift current_T toward target, faster when the compressor is on
+        rate = self.cooling_rate if self.compressor_on else self.cooling_rate * 0.1
+        delta = self.target - self.current_T
+        step = np.clip(delta, -rate, rate)
+        noise = (np.random.rand() - 0.5) * 0.05
+        self.current_T = self.current_T + step + noise
 
+        pressure_f = 101300.0 + (np.random.rand() - 0.5) * 50
+        pressure_g = 101300.0 + (np.random.rand() - 0.5) * 50
+
+        # Other channels loosely track the primary channel with small fixed offsets
+        return [
+            self.current_T,
+            self.current_T + 0.5,
+            self.current_T + 1.0,
+            self.current_T - 0.5,
+            self.current_T - 1.0,
+            pressure_f,
+            pressure_g,
+        ]

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -59,27 +59,33 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
-    # Shamrock grating parameters
-    grating_params={
-        'focal_length_mm':163,
-        'delta':np.float64(-0.20488367116307532),
-        'gamma':np.float64(2.021864300924973),
-        'n0':np.float64(511.0), # Central pixel
-        'offset_adjust':0,
-        'd_grating':np.float64(6666.666666666667),
-        'x_pixel':26000.0,
-        'curvature':np.float64(3.1224154313329654e-06),
-    }
-    # SpectraPro 2300i grating parameters
-    grating_params = {
+    grating_params_stresing={
         'focal_length_mm':300,
-        'delta':np.float64(0),
-        'gamma':np.float64(0),
-        'n0':np.float64(511.0), # Central pixel
+        'f':np.float64(305381928.6149399),
+        'delta':np.float64(0.11432112488955509),
+        'gamma':np.float64(0.5337955112241486),
+        'n0':np.float64(539.4), # Central pixel
         'offset_adjust':0,
-        'd_grating':None,
-        'x_pixel':None,
-        'curvature':np.float64(0),
+        'd_grating':833.3333333333334,
+        'x_pixel':24000.0,
+        'curvature':np.float64(5.736575254871788e-07),
+    }
+    f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
+    grating_params_pixis = {
+        'focal_length_mm':300,
+        'f':np.float64(300000000.0),
+        'delta':np.float64(0.06),
+        'gamma':np.float64(0.5),
+        'n0':np.float64(516.6), # Central pixel
+        'offset_adjust':0,
+        'd_grating':833.3333333333334,
+        'x_pixel':26000,
+        'curvature':np.float64(0.0),
+    }
+
+    grating_params = {
+        'Stresing': grating_params_stresing,
+        'Pixis': grating_params_pixis
     }
     Monochrom = SpectraPro2300i(grating_params) 
 
@@ -92,7 +98,7 @@ def load_instruments():
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
-        'calibrated': False,
+        'calibrated': True,
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
@@ -100,7 +106,7 @@ def load_instruments():
     pixis_params = {
         'pixel_size_mm':26e-3,
         'num_pixels':1024,
-        'calibrated':False,
+        'calibrated':True,
         'calibrationThirdOrder':0,
         'calibrationSlope':0,
         'calibrationOffset':0

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -10,6 +10,8 @@ from drivers.SLMDemo import SLMDemo
 from drivers.Stresing import StresingCamera
 from drivers.Shamrock import Shamrock 
 from drivers.Optidry250 import CryoPasqal
+from drivers.Pixis import Pixis
+from drivers.SpectraPro2300i import SpectraPro2300i
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +59,9 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
+    # Shamrock grating parameters
     grating_params={
         'focal_length_mm':163,
-        'f':np.float64(330605663.74965495),
         'delta':np.float64(-0.20488367116307532),
         'gamma':np.float64(2.021864300924973),
         'n0':np.float64(511.0), # Central pixel
@@ -68,11 +70,25 @@ def load_instruments():
         'x_pixel':26000.0,
         'curvature':np.float64(3.1224154313329654e-06),
     }
-    Monochrom = Shamrock(grating_params) 
+    # SpectraPro 2300i grating parameters
+    grating_params = {
+        'focal_length_mm':300,
+        'delta':np.float64(0),
+        'gamma':np.float64(0),
+        'n0':np.float64(511.0), # Central pixel
+        'offset_adjust':0,
+        'd_grating':None,
+        'x_pixel':None,
+        'curvature':np.float64(0),
+    }
+    Monochrom = SpectraPro2300i(grating_params) 
+
+    
+    
     devices['Monochrom'] = Monochrom 
     logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
 
-    # initialize StresingDemo
+    # initialize Cameras
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
@@ -80,6 +96,14 @@ def load_instruments():
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
+    }
+    pixis_params = {
+        'pixel_size_mm':26e-3,
+        'num_pixels':1024,
+        'calibrated':False,
+        'calibrationThirdOrder':0,
+        'calibrationSlope':0,
+        'calibrationOffset':0
     }
 
     spectrometers = {}
@@ -91,6 +115,14 @@ def load_instruments():
         logger.info('%s Stresing connected' % datetime.datetime.now())
     except Exception as e:
         logger.warning(f'Stresing failed: {e}')
+
+    try:
+        camera = Pixis(pixis_params)
+        spectrometers['Pixis'] = camera
+        camera.attach_to_monochromator(Monochrom)
+        logger.info('%s Pixis connected' % datetime.datetime.now())
+    except Exception as e:
+        logger.warning(f'Pixis failed: {e}')
 
     try:
         from drivers.OceanSpectrometer import OceanSpectrometer

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -64,7 +64,7 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['unit'] = ' celsius'
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
-        self.parameter_display_dict['sensor_T']['read'] = True
+        self.parameter_display_dict['sensor_T']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -223,8 +223,9 @@ class Pixis(QtCore.QThread):
         spectrum = spectrum[0, :]
         return spectrum
 
-    def update_temperature(self,temperature):
+    def update_temperature(self, temperature):
         self.parameter_dict['sensor_T'] = temperature
+        self.parameter_display_dict['sensor_T']['val'] = temperature
 
 
 class CameraWorker(QtCore.QThread):

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -119,7 +119,8 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array()
+        self.calculate_wavelength_array()
+        return self.wavelengths
 
     def calculate_wavelength_array(self):
         """
@@ -136,32 +137,32 @@ class Pixis(QtCore.QThread):
             focal_length_mm = self.hardware_params['focal_length_mm']
             num_pixels = self.hardware_params['num_pixels']
         
-        calibrated = False
-        if calibrated:
-            pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 300  # specs of SP2150
-            num_pixels = 1024  # specs of PIXIS
+        if self.hardware_params['calibrated']:
 
-            #
+            pixel_size_mm = 26 / 1E3  # specs of PIXIS
+            focal_length_mm = 300  # specs of SP2300
+            num_pixels = 1024  # specs of PIXIS
 
             wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
             # calibration from notebook
-            f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
-
-
+            f=self.hardware_params['f']
+            delta=self.hardware_params['delta']
+            gamma=self.hardware_params['gamma']
+            n0=self.hardware_params['n0']
+            offset_adjust=self.hardware_params['offset_adjust']
+            d_grating=self.hardware_params['d_grating']
+            x_pixel=self.hardware_params['x_pixel']
+            curvature=self.hardware_params['curvature']
 
             n = px - (n0 + offset_adjust * wl_center)
-
-            # print('psi top', m_order* wl_center)
-            # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
 
             psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
             eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
-            wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+            self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
             focal_length_mm = 300  # specs of SP2150
@@ -177,9 +178,7 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-
-        return wavelengths
+            self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
     def attach_to_monochromator(self,monochromator):
         """
@@ -189,7 +188,7 @@ class Pixis(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Pixis'))
     
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -22,21 +22,21 @@ from PyQt5 import QtCore
 from collections import defaultdict
 from pylablib.devices import PrincetonInstruments
 import time
-import serial
 import re
 
 class Pixis(QtCore.QThread):
 
     name = 'Pixis'
     
-    def __init__(self):
+    def __init__(self, hardware_params):
         super(Pixis, self).__init__()
 
         #self.camera.start()
-        self.wavelength =  np.linspace(200,1000,1024) # get property from Worker
+        self.wavelength = np.linspace(200,1000,1024) # get property from Worker
         self.px0 = np.linspace(1,1024,1024)
-        self.spec_length = (252,1024) # get property from Worker
+        self.spec_length = 1024 #(252,1024) # get property from Worker
         self.image = np.zeros(self.spec_length)
+        self.hardware_params = hardware_params
 
         # Indicate shutter, required to discriminate between different detectors
         self.shutter = True
@@ -46,30 +46,6 @@ class Pixis(QtCore.QThread):
         self.int_time = 100
         self.binned_spec = np.zeros(self.spec_length)
         self.new_spectrum = False
-
-        # set up spectrograph
-        self.serial_busy = False
-        port = 'COM6'
-        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
-                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
-        # get startup values
-        self.grating = float(self.write_command('?GRATING')[0])
-        numbers = self.write_command('?GRATINGS')
-        self.num_gratings = int((len(numbers)-8)/2)
-        self.grating_densities = np.zeros(self.num_gratings)
-        self.grating_blazes = np.zeros(self.num_gratings)
-        for i in range(self.num_gratings):
-            self.grating_densities[i] = numbers[i*3 + 1]
-            self.grating_blazes[i] = numbers[i * 3 + 2]
-        self.center_wl = float(self.write_command('?NM')[0])
-        print(self.center_wl)
-        print(self.grating_densities)
-        print(self.grating_blazes)
-        print(self.grating)
-        print('SP2150 grating info: ', numbers)
-        print('SP2150 grating densities: ',self.grating_densities)
-        print('SP2150 grating blazes: ',self.grating_blazes)
-        print('SP2150 selected grating: ',self.grating)
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -89,14 +65,6 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
         self.parameter_display_dict['sensor_T']['read'] = True
-        self.parameter_display_dict['center_wl']['val'] = self.center_wl
-        self.parameter_display_dict['center_wl']['unit'] = ' nm'
-        self.parameter_display_dict['center_wl']['max'] = 2000
-        self.parameter_display_dict['center_wl']['read'] = False
-        self.parameter_display_dict['grating']['val'] = self.grating
-        self.parameter_display_dict['grating']['unit'] = ' grat'
-        self.parameter_display_dict['grating']['max'] = 3
-        self.parameter_display_dict['grating']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -108,6 +76,10 @@ class Pixis(QtCore.QThread):
         print(PrincetonInstruments.list_cameras())
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
+
+        # set the ROI so the camera is acting like a 1D array of 1024 pixels
+        roi = {"x": 0, "width": 1024, "x_binning": 1, "y": 0, "height": 1, "y_binning": 1}
+        self.camera.set_attribute_value("ROIs", [roi])
 
         # initialize camera
         self.worker = CameraWorker(self.camera,self.int_time)
@@ -134,16 +106,6 @@ class Pixis(QtCore.QThread):
         elif parameter == 'avg_scan':
             self.parameter_dict['avg_scan'] = value
             self.avg_scan = int(value)
-        elif parameter == 'center_wl':
-            cmd = f'{value:0.3f} GOTO'
-            self.write_command(cmd)
-            self.parameter_dict['center_wl'] = value
-            self.center_wl = value
-        elif parameter == 'grating':
-            cmd = f'{value:1.0f} GRATING'
-            self.write_command(cmd)
-            self.parameter_dict['grating'] = value
-            self.grating = value
 
 
     def update_spectrum(self, spec, int_time):
@@ -157,28 +119,32 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array(self.center_wl,self.grating_densities[int(self.grating-1)])
+        return self.calculate_wavelength_array()
 
-    def calculate_wavelength_array(self,center_wavelength_nm,grating_lines_per_mm):
+    def calculate_wavelength_array(self):
         """
         Calculate the wavelength array for a PIXIS camera on SP-2150 spectrograph.
 
         Parameters:
-            center_wavelength_nm: Central wavelength (nm)
-            grating_lines_per_mm: Groove density (lines/mm)
 
         Returns:
             wavelengths: 1D numpy array of wavelengths (nm)
         """
-        calibrated = True
+        if self.monochromator is not None:
+            self.center_wavelength,self.grating_lines_per_mm=self.monochromator.get_monochromator_parameters()
+            pixel_size_mm =self.hardware_params['pixel_size_mm'] 
+            focal_length_mm = self.hardware_params['focal_length_mm']
+            num_pixels = self.hardware_params['num_pixels']
+        
+        calibrated = False
         if calibrated:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             #
 
-            wl_center = center_wavelength_nm
+            wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
@@ -198,11 +164,11 @@ class Pixis(QtCore.QThread):
             wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             # Calculate linear dispersion (nm/mm)
-            dispersion = 1e6 / (focal_length_mm * grating_lines_per_mm)
+            dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
             # Center pixel
             center_pixel = num_pixels // 2
@@ -211,10 +177,20 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = center_wavelength_nm + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
+            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
         return wavelengths
 
+    def attach_to_monochromator(self,monochromator):
+        """
+            Attaches the camera to a monochromator, letting the camera interface know where to get the monochromator parameters from.
+            input:
+                - monochromator (Monochromator QThread): The interface to the monochromator
+        """
+        self.monochromator=monochromator
+        self.type='Spectrometer'
+        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+    
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """
         self.camera.start_acquisition()
@@ -229,6 +205,7 @@ class Pixis(QtCore.QThread):
         """ Gets the intensity. The example include the possibility of averaging several spectra and to
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
+        self.start_acquisition()
         if self.avg_scan == 1:
             while not self.new_spectrum:
                 time.sleep(0.01)
@@ -243,35 +220,12 @@ class Pixis(QtCore.QThread):
                 spectrum = spectrum + self.spectrum
                 self.new_spectrum = False
             spectrum = spectrum / self.avg_scan
+        self.stop_acquisition()
+        spectrum = spectrum[0, :]
         return spectrum
 
     def update_temperature(self,temperature):
         self.parameter_dict['sensor_T'] = temperature
-
-    def write_command(self, cmd):
-        """ Command to write to serial handles timeout by blocking serial commands
-        Args:
-            ser: serial object
-            cmd: write command as defined in PI API
-
-        Returns: read string with only digit content. For troubleshooting, consider printing
-        the entire answer string
-        """
-        cmd_bytes = cmd.encode('ASCII')
-        self.ser.write(cmd_bytes + b"\r")
-        out = bytearray()
-        char = b""
-        missed_char_count = 0
-        while char != b"k":
-            char = self.ser.read()
-            if char == b"":  # handles a timeout here
-                missed_char_count += 1
-                self.serial_busy = True
-                time.sleep(0.1)
-            out += char
-        self.serial_busy = False
-        return re.findall(r'\d+', out.decode().strip())
-
 
 
 class CameraWorker(QtCore.QThread):
@@ -288,7 +242,7 @@ class CameraWorker(QtCore.QThread):
 
         # definition of some parameters
         self.camera = camera
-        self.spec_length = (252,1024)
+        self.spec_length = 1024
         self.change_int_time = False
         self.spectrum = np.zeros(self.spec_length)
         self.int_time = int_time

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -110,7 +110,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
 
-    def get_hardware_parameters(self):
+    def get_hardware_parameters(self, name):
         """
             Returns the hardware parameters of the monochromator
             output:
@@ -125,7 +125,8 @@ class SpectraPro2300i(QtCore.QThread):
                     - curvature
 
         """
-        return self.hardware_params
+        return self.hardware_params[name]
+    
     def get_monochromator_parameters(self):
         """
             Returns the current parameters of the monochromator.
@@ -133,6 +134,4 @@ class SpectraPro2300i(QtCore.QThread):
                 - central_wavelength (np.float): the central wavelength in nm
                 - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
         """
-        return self.center_wl, self.grating_densities[int(self.grating)]
-
-
+        return self.center_wl, self.grating_densities[int(self.grating-1)]

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -1,0 +1,138 @@
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: KatieKoch, Felix Thouin
+"""
+
+import numpy as np
+from PyQt5 import QtCore
+from collections import defaultdict
+import time
+import serial
+import re
+
+class SpectraPro2300i(QtCore.QThread):
+    
+    name = 'SpectraPro2300i'
+    type = 'Monochromator'
+    
+    def __init__(self,hardware_params):
+        super(SpectraPro2300i, self).__init__()
+
+        # set up spectrograph
+        self.serial_busy = False
+        port = 'COM5'
+        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
+                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
+        # get startup values
+        self.grating = float(self.write_command('?GRATING')[0])
+        numbers = self.write_command('?GRATINGS')
+        self.num_gratings = int((len(numbers)-8)/2)
+        self.grating_densities = np.zeros(self.num_gratings)
+        self.grating_blazes = np.zeros(self.num_gratings)
+        for i in range(self.num_gratings):
+            self.grating_densities[i] = numbers[i*3 + 1]
+            self.grating_blazes[i] = numbers[i * 3 + 2]
+        self.center_wl = float(self.write_command('?NM')[0])
+        print(self.center_wl)
+        print(self.grating_densities)
+        print(self.grating_blazes)
+        print(self.grating)
+        print('SP2300 grating info: ', numbers)
+        print('SP2300 grating densities: ',self.grating_densities)
+        print('SP2300 grating blazes: ',self.grating_blazes)
+        print('SP2300 selected grating: ',self.grating)
+
+        # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
+        self.hardware_params=hardware_params
+        # set parameter dict
+        self.parameter_dict = defaultdict()
+        """ Set up the parameter dict. 
+        Here, all properties of parameters to be handled by the parameter dict are defined."""
+        
+        self.parameter_display_dict = defaultdict(dict)
+        
+        self.parameter_dict['central_wave'] = self.center_wl
+        self.parameter_dict['grating'] = self.grating
+        
+        self.parameter_display_dict['central_wave']['val'] = self.center_wl
+        self.parameter_display_dict['central_wave']['unit'] = ' nm'
+        self.parameter_display_dict['central_wave']['min'] = 200.00
+        self.parameter_display_dict['central_wave']['max'] = 1100.00
+        self.parameter_display_dict['central_wave']['read'] = False
+        
+        self.parameter_display_dict['grating']['val'] = self.grating
+        self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['grating']['max'] = 3
+        self.parameter_display_dict['grating']['read'] = False
+
+        # set up parameter dict that only contains value. (faster to access)
+        self.parameter_dict = {}
+        for key in self.parameter_display_dict.keys():
+            self.parameter_dict[key] = self.parameter_display_dict[key]['val']
+    
+    def write_command(self, cmd):
+        """ Command to write to serial handles timeout by blocking serial commands
+        Args:
+            ser: serial object
+            cmd: write command as defined in PI API
+
+        Returns: read string with only digit content. For troubleshooting, consider printing
+        the entire answer string
+        """
+        cmd_bytes = cmd.encode('ASCII')
+        self.ser.write(cmd_bytes + b"\r")
+        out = bytearray()
+        char = b""
+        missed_char_count = 0
+        while char != b"k":
+            char = self.ser.read()
+            if char == b"":  # handles a timeout here
+                missed_char_count += 1
+                self.serial_busy = True
+                time.sleep(0.1)
+            out += char
+        self.serial_busy = False
+        return re.findall(r'\d+', out.decode().strip())
+   
+    def set_parameter(self, parameter, value):
+        """REQUIRED. This function defines how changes in the parameter tree are handled.
+        In devices with workers, a pause of continuous acquisition might be required. """
+        if parameter == 'central_wave':
+            cmd = f'{value:0.3f} GOTO'
+            self.write_command(cmd)
+            self.parameter_dict['center_wave'] = value
+            self.center_wl = value
+        elif parameter == 'grating':
+            cmd = f'{value:1.0f} GRATING'
+            self.write_command(cmd)
+            self.parameter_dict['grating'] = value
+            self.grating = value
+
+    def get_hardware_parameters(self):
+        """
+            Returns the hardware parameters of the monochromator
+            output:
+                - hardware_parameters (dict): A dictionnary of all hardware parameters including:
+                    - f
+                    - delta
+                    - gamma
+                    - n0
+                    - offset_adjust
+                    - d_grating
+                    - x_pixel
+                    - curvature
+
+        """
+        return self.hardware_params
+    def get_monochromator_parameters(self):
+        """
+            Returns the current parameters of the monochromator.
+            output:
+                - central_wavelength (np.float): the central wavelength in nm
+                - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
+        """
+        return self.center_wl, self.grating_densities[int(self.grating)]
+
+

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -35,6 +35,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.grating_densities[i] = numbers[i*3 + 1]
             self.grating_blazes[i] = numbers[i * 3 + 2]
         self.center_wl = float(self.write_command('?NM')[0])
+        self.mirror = float(self.write_command('?MIR')[0])
         print(self.center_wl)
         print(self.grating_densities)
         print(self.grating_blazes)
@@ -55,6 +56,7 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_dict['central_wave'] = self.center_wl
         self.parameter_dict['grating'] = self.grating
+        self.parameter_dict['mirror'] = self.mirror
         
         self.parameter_display_dict['central_wave']['val'] = self.center_wl
         self.parameter_display_dict['central_wave']['unit'] = ' nm'
@@ -64,8 +66,15 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_display_dict['grating']['val'] = self.grating
         self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['mirror']['min'] = 1
         self.parameter_display_dict['grating']['max'] = 3
         self.parameter_display_dict['grating']['read'] = False
+
+        self.parameter_display_dict['mirror']['val'] = self.mirror
+        self.parameter_display_dict['mirror']['unit'] = ' mirror'
+        self.parameter_display_dict['mirror']['min'] = 0
+        self.parameter_display_dict['mirror']['max'] = 1
+        self.parameter_display_dict['mirror']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -109,6 +118,11 @@ class SpectraPro2300i(QtCore.QThread):
             self.write_command(cmd)
             self.parameter_dict['grating'] = value
             self.grating = value
+        elif parameter == 'mirror':
+            cmd = f'{value:1.0f} MIRROR'
+            self.write_command(cmd)
+            self.parameter_dict['mirror'] = value
+            self.mirror = value
 
     def get_hardware_parameters(self, name):
         """

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -14,7 +14,6 @@ set_parameter function (assign set functions)
 import numpy as np
 from PyQt5 import QtCore
 from collections import defaultdict
-import time
 from pathlib import Path
 import matplotlib.pyplot as plt
 from drivers.StresingDriver import camera_settings
@@ -27,6 +26,19 @@ import logging
 import datetime
 
 logger = logging.getLogger(__name__)
+
+""" Trigger sources the board understands, as documented in StresingDriver.init_driver(). sti and bti
+share the numbering for the external inputs but diverge above 4, so they are listed separately rather
+than exposed as raw numbers. """
+TRIGGER_INPUTS = {'I': 0, 'S1': 1, 'S2': 2, 'I gated by S2': 3}
+TRIGGER_TIMER = 4
+CHOPPER_INPUTS = {'S1': 5, 'S2': 6, 'S1 and S2': 7}
+
+CONTINUOUS = 'continuous'
+EXTERNAL = 'external'
+CHOPPER = 'chopper'
+
+
 class StresingCamera(QtCore.QThread):
 
     name = 'StresingCamera'
@@ -35,9 +47,11 @@ class StresingCamera(QtCore.QThread):
         super(StresingCamera, self).__init__()
 
         # initialize Worker
+        """ The worker is kept as the signal carrier that publishes each acquired spectrum, but its
+        thread is not started: the readout is a pull, driven by get_intensities() from the measurement
+        thread, so a polling loop has nothing to do. Not starting it also avoids leaving a thread
+        running at shutdown. """
         self.worker = StresingWorker()
-        self.worker.sendSpectrum.connect(self.update_spectrum) # connect where signals of worker go to.
-        self.worker.start()
         self.type = 'Camera'
 
         # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
@@ -84,6 +98,10 @@ class StresingCamera(QtCore.QThread):
         self.btimer = int(float(config.get("Board0","btimer")))
         self.stimer = int(config.get("Board0","stimer"))
         self.new_spectrum = False
+
+        """ Deadline used when the board is waiting on an external signal. Without it a trigger that
+        never arrives leaves the acquisition thread stuck inside the DLL with no way back. """
+        self.trigger_timeout_s = 5.0
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -248,10 +266,6 @@ class StresingCamera(QtCore.QThread):
             self.new_spectrum = False
         init_measure(self) # type: ignore
 
-    def update_spectrum(self, spectrum):
-        self.spectrum = spectrum
-        self.new_spectrum = True
-
     def calculate_wavelength_array(self):
         """
             Calculate the wavelength array for the pixels of the Stresing camera using the hardware parameters from the camera and the attached monochromator. 
@@ -321,6 +335,86 @@ class StresingCamera(QtCore.QThread):
         self.type='Spectrometer'
         self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
+    def get_acquisition_mode(self):
+        """
+            Returns the current trigger setup in the vocabulary the interface uses, so a widget can
+            show the mode rather than the raw sti/bti register values.
+        """
+        if self.bti in CHOPPER_INPUTS.values():
+            mode = CHOPPER
+        elif self.sti == TRIGGER_TIMER and self.bti == TRIGGER_TIMER:
+            mode = CONTINUOUS
+        else:
+            mode = EXTERNAL
+        inputs = {v: k for k, v in TRIGGER_INPUTS.items()}
+        choppers = {v: k for k, v in CHOPPER_INPUTS.items()}
+        return {'mode': mode,
+                'scan_trigger': 'timer' if self.sti == TRIGGER_TIMER else inputs.get(self.sti, 'I'),
+                'chopper': choppers.get(self.bti, 'S1'),
+                'scan_interval_us': self.stimer,
+                'block_interval_us': self.btimer,
+                'timeout_s': self.trigger_timeout_s}
+
+    def set_acquisition_mode(self, mode, scan_trigger='I', chopper='S1',
+                             scan_interval_us=None, block_interval_us=None, timeout_s=None):
+        """
+            Sets sti, bti and their timers as one coherent choice instead of four loose registers.
+            input:
+                - mode (str): CONTINUOUS (the board drives itself), EXTERNAL (one readout per trigger
+                  pulse) or CHOPPER (blocks gated by a chopper signal)
+                - scan_trigger (str): key of TRIGGER_INPUTS, or 'timer', for what starts a readout.
+                  Ignored in CONTINUOUS.
+                - chopper (str): key of CHOPPER_INPUTS. Only used in CHOPPER.
+                - scan_interval_us (int): time between readouts, applied only when readouts run on
+                  the internal timer
+                - block_interval_us (int): time between blocks, applied only in CONTINUOUS
+                - timeout_s (float): how long to wait for an external signal before giving up
+        """
+        if mode == CONTINUOUS:
+            sti = bti = TRIGGER_TIMER
+        elif mode == EXTERNAL:
+            sti = bti = TRIGGER_INPUTS[scan_trigger]
+        elif mode == CHOPPER:
+            bti = CHOPPER_INPUTS[chopper]
+            sti = TRIGGER_TIMER if scan_trigger == 'timer' else TRIGGER_INPUTS[scan_trigger]
+        else:
+            raise ValueError('Unknown acquisition mode: %s' % mode)
+
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        cam.sti_mode, cam.bti_mode = sti, bti
+        self.sti, self.bti = sti, bti
+
+        """ The board only reads a timer in the mode that uses it. Writing them in the other modes
+        would leave values on screen that have no effect, which is what made the old parameter table
+        misleading. """
+        if sti == TRIGGER_TIMER and scan_interval_us:
+            cam.stime_in_microsec = int(scan_interval_us)
+            self.stimer = int(scan_interval_us)
+        if bti == TRIGGER_TIMER and block_interval_us:
+            cam.btime_in_microsec = int(block_interval_us)
+            self.btimer = int(block_interval_us)
+        if timeout_s is not None:
+            self.trigger_timeout_s = float(timeout_s)
+
+        # Keep the generic parameter tree in step with what was set here.
+        for key, value in (('Scan_Trig', self.sti), ('Block_Trig', self.bti),
+                           ('Scan_Timer', self.stimer), ('Block_Timer', self.btimer)):
+            self.parameter_dict[key] = value
+            self.parameter_display_dict[key]['val'] = value
+
+        self.new_spectrum = False
+        init_measure(self) # type: ignore
+        logger.info('%s Stresing acquisition mode: %s (sti=%d, bti=%d)'
+                    % (datetime.datetime.now(), mode, sti, bti))
+
+    def waits_for_external_signal(self):
+        """
+            True when either trigger depends on a signal the board does not generate itself, i.e.
+            when an acquisition can legitimately never complete.
+        """
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        return cam.sti_mode != TRIGGER_TIMER or cam.bti_mode != TRIGGER_TIMER
+
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
 
@@ -332,21 +426,34 @@ class StresingCamera(QtCore.QThread):
         return self.wavelengths
 
     def get_intensities(self):
-        use_blocking_call = True
-        self.spectrum = StresingWorker.worker_spectrum(self, use_blocking_call)
-        while not self.new_spectrum:
-            time.sleep(0.01)
-            self.new_spectrum = False
+        """ The blocking DLL call cannot be interrupted, so it is only used when the board drives
+        itself and the scans are guaranteed to come. Anything waiting on an external signal goes
+        through the polling path, which honours trigger_timeout_s. """
+        use_blocking_call = not self.waits_for_external_signal()
+        self.acquire_spectrum(use_blocking_call)
         self.spec = np.array(self.spectrum[13:-1])
         self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
+        """ Publish the same data the caller gets, so a live view can follow the acquisition without
+        going through DataHandling. """
+        self.worker.sendSpectrum.emit(self.spec)
         return self.spec
 
+    def acquire_spectrum(self, use_blocking_call):
+        """
+            Reads one spectrum off the board, in the calling thread.
+            input:
+                - use_blocking_call (bool): whether to wait in the DLL until the readout is complete
+        """
+        init_measure(self) # type: ignore
+        timeout_s = None if use_blocking_call else self.trigger_timeout_s
+        self.spectrum = measure(self, use_blocking_call, timeout_s) # type: ignore
+        self.new_spectrum = True
+
 class StresingWorker(QtCore.QThread):
-    """ This is a DemoWorker for the Stresing Camera.
-    It continously acquires spectra and emits them to the Interface.
-    It interrupts data acquisition if an ac_time change is requested. Its important because most
-    hardware can only handle one command at a time, acquiring or changing settings.  """
+    """ Publishes the spectra acquired from the Stresing camera to the interface.
+    The camera is read synchronously by StresingCamera.acquire_spectrum() in the thread that asks for
+    a spectrum, so this worker carries the signal only and its thread is never started. """
     # These are signals that allow to send data from a child thread to the parent hierarchy.
     sendSpectrum = QtCore.pyqtSignal(np.ndarray)
 
@@ -354,20 +461,7 @@ class StresingWorker(QtCore.QThread):
         super(StresingWorker, self).__init__() # Elevates this thread to be independent.
         self.new_spectrum = False
 
-    def run(self):
-        while True:
-            time.sleep(0.01)
-            if self.new_spectrum:
-                self.new_spectrum = False
-                self.sendSpectrum.emit(self.spectrum)
-            pass
 
-    def worker_spectrum(self, use_blocking_call):
-        init_measure(self) # type: ignore
-        self.spectrum = measure(self, use_blocking_call) # type: ignore
-        self.new_spectrum = True
-        return self.spectrum
-    
 class CaseInsensitiveConfig(configparser.ConfigParser):
     """ This class extends Python’s built-in configparser.ConfigParser to make both section names and option names case-insensitive.
     Normally, ConfigParser is only case-insensitive for option names, not section names, so this subclass enforces lowercase normalization for both. """

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -426,11 +426,7 @@ class StresingCamera(QtCore.QThread):
         return self.wavelengths
 
     def get_intensities(self):
-        """ The blocking DLL call cannot be interrupted, so it is only used when the board drives
-        itself and the scans are guaranteed to come. Anything waiting on an external signal goes
-        through the polling path, which honours trigger_timeout_s. """
-        use_blocking_call = not self.waits_for_external_signal()
-        self.acquire_spectrum(use_blocking_call)
+        self.acquire_spectrum()
         self.spec = np.array(self.spectrum[13:-1])
         self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
@@ -439,15 +435,35 @@ class StresingCamera(QtCore.QThread):
         self.worker.sendSpectrum.emit(self.spec)
         return self.spec
 
-    def acquire_spectrum(self, use_blocking_call):
+    def expected_duration_s(self):
+        """
+            How long one acquisition should take when the board drives itself, from the timers it was
+            given. Used to size the deadline, so a stalled board is caught in proportion to what the
+            settings actually ask for.
+        """
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        scans, blocks = max(int(self.sample), 1), max(int(self.block), 1)
+        seconds = 0.0
+        if cam.sti_mode == TRIGGER_TIMER:
+            seconds += scans * blocks * self.stimer / 1e6
+        if cam.bti_mode == TRIGGER_TIMER:
+            seconds += blocks * self.btimer / 1e6
+        return seconds
+
+    def acquire_spectrum(self):
         """
             Reads one spectrum off the board, in the calling thread.
-            input:
-                - use_blocking_call (bool): whether to wait in the DLL until the readout is complete
+            Always polls with a deadline. The blocking DLL call cannot be interrupted and has been
+            seen never to return when the board is in a bad state, which hangs whichever thread asked
+            for the spectrum with no way back -- including the interface itself. Waiting on the board
+            is not worth losing the ability to give up.
         """
         init_measure(self) # type: ignore
-        timeout_s = None if use_blocking_call else self.trigger_timeout_s
-        self.spectrum = measure(self, use_blocking_call, timeout_s) # type: ignore
+        if self.waits_for_external_signal():
+            timeout_s = self.trigger_timeout_s
+        else:
+            timeout_s = max(self.expected_duration_s() * 3, 5.0)
+        self.spectrum = measure(self, False, timeout_s) # type: ignore
         self.new_spectrum = True
 
 class StresingWorker(QtCore.QThread):

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -264,9 +264,13 @@ class StresingCamera(QtCore.QThread):
 
             if self.hardware_params['calibrated']:
 
+                pixel_size_mm = 24 / 1E3  # specs of Sresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of stresing
+
                 wl_center = self.center_wavelength
                 m_order = 1
-                px = np.linspace(1,1024,1024)
+                px = np.linspace(1,1010,1010)
 
                 # calibration from notebook
                 f=self.hardware_params['f']
@@ -280,14 +284,17 @@ class StresingCamera(QtCore.QThread):
 
                 n = px - (n0 + offset_adjust * wl_center)
 
-                # print('psi top', m_order* wl_center)
-                # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
-
                 psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
                 eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
                 self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+
             else:
+
+                pixel_size_mm = 24 / 1E3  # specs of Stresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of Stresing
+
                 # Calculate linear dispersion (nm/mm)
                 dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
@@ -299,8 +306,7 @@ class StresingCamera(QtCore.QThread):
 
                 # Wavelength at each pixel
                 self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-                # Refine the calibration using a mercury spectral lamp
-                self.wavelengths = self.hardware_params['calibrationThirdOrder']*self.wavelengths**2 + self.hardware_params['calibrationSlope']*self.wavelengths + self.hardware_params['calibrationOffset']
+
         else:
             self.wavelengths= self.hardware_params['num_pixels']
             logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength'%datetime.datetime.now())
@@ -313,7 +319,7 @@ class StresingCamera(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
@@ -332,6 +338,7 @@ class StresingCamera(QtCore.QThread):
             time.sleep(0.01)
             self.new_spectrum = False
         self.spec = np.array(self.spectrum[13:-1])
+        self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
         return self.spec
 

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -459,11 +459,11 @@ class StresingCamera(QtCore.QThread):
             is not worth losing the ability to give up.
         """
         init_measure(self) # type: ignore
-        if self.waits_for_external_signal():
-            timeout_s = self.trigger_timeout_s
-        else:
-            timeout_s = max(self.expected_duration_s() * 3, 5.0)
-        self.spectrum = measure(self, False, timeout_s) # type: ignore
+        """ Only an acquisition that depends on an external signal needs the trigger watch. On the
+        internal timer the board drives itself and the readouts are guaranteed, so waiting for a
+        trigger there would just add a delay to every spectrum. """
+        timeout_s = self.trigger_timeout_s if self.waits_for_external_signal() else None
+        self.spectrum = measure(self, True, timeout_s) # type: ignore
         self.new_spectrum = True
 
 class StresingWorker(QtCore.QThread):

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -194,15 +194,42 @@ def abort_measure(self):
     self.dll.DLLAbortMeasurement()
 
 
-def measure(self, use_blocking_call, timeout_s=None):
+def wait_for_trigger(self, timeout_s):
+    """
+        Waits until the board reports a scan trigger, and raises if none appears.
+        Used before committing to the blocking start, which cannot be interrupted: this way an
+        input with no signal on it is reported instead of freezing the caller.
+        input:
+            - timeout_s (float): how long to wait for the first trigger
+    """
+    """ Both take a pointer to the flag as their second argument. Calling them with the board number
+    alone compiles and runs, and corrupts memory: it cost an access violation to find out. """
+    detected = ctypes.c_uint8(0)
+    ptr_detected = ctypes.pointer(detected)
+    self.dll.DLLResetScanTriggerDetected(self.drvno, ptr_detected)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        self.dll.DLLGetScanTriggerDetected(self.drvno, ptr_detected)
+        if detected.value:
+            break
+        if time.monotonic() > deadline:
+            self.dll.DLLOpenShutter(self.drvno)
+            raise TimeoutError(
+                'No trigger detected after %.1f s. The board is configured to start its readouts '
+                'on an external signal (sti=%d) and nothing is arriving on that input.'
+                % (timeout_s, self.settings.camera_settings[self.drvno].sti_mode))
+        time.sleep(0.001)
+
+
+def measure(self, use_blocking_call=True, timeout_s=None):
     """
         Runs one measurement and returns the spectrum averaged over samples and blocks.
         input:
-            - use_blocking_call (bool): wait inside the DLL until every scan is collected. Only safe
-              when the scans are guaranteed to come, i.e. on the internal timer.
-            - timeout_s (float): non-blocking path only. Gives up after this many seconds if the
-              board is still waiting for scans, instead of hanging forever on a trigger that never
-              arrives. None waits indefinitely.
+            - use_blocking_call (bool): kept for compatibility. The non-blocking start returns
+              'An unknown error occurred' on this board, checked against the instrument, so the
+              blocking call is the only one that actually starts a measurement.
+            - timeout_s (float): when set, wait this long for a trigger before starting. Leave None
+              when the board drives itself, where the readouts are guaranteed to come.
     """
     """ Clear a measurement the board may still be running from a previous attempt. Without this an
     acquisition that was aborted, timed out or killed leaves the board busy, and every later one
@@ -216,34 +243,16 @@ def measure(self, use_blocking_call, timeout_s=None):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
-    if use_blocking_call:
-        # Start the measurement. This is the blocking call, which means it will return when the measurement is finished. This is done to ensure that no data access happens before all data is collected.
-        status = self.dll.DLLStartMeasurement_blocking()
-        if(status != 0):
-            raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
-    else:
-        # Start the measurement. This is the nonblocking call, which means it will return immediately.
-        self.dll.DLLStartMeasurement_nonblocking()
+    """ The blocking call has no way out, so anything that depends on an external signal waits for a
+    trigger to actually appear first. On the internal timer the measurement takes as long as the
+    timers say -- 0.11 s for ten readouts at 10 ms, measured -- and is entered directly. """
+    if timeout_s is not None:
+        wait_for_trigger(self, timeout_s)
 
-        cur_sample = ctypes.c_int64(-2)
-        ptr_cur_sample = ctypes.pointer(cur_sample)
-        cur_block = ctypes.c_int64(-2)
-        ptr_cur_block = ctypes.pointer(cur_block)
-
-        deadline = None if timeout_s is None else time.monotonic() + timeout_s
-        while cur_sample.value < self.settings.nos-1 or cur_block.value < self.settings.nob-1:
-            self.dll.DLLGetCurrentScanNumber(self.drvno, ptr_cur_sample, ptr_cur_block)
-            if deadline is not None and time.monotonic() > deadline:
-                abort_measure(self)
-                self.dll.DLLOpenShutter(self.drvno)
-                raise TimeoutError(
-                    'No scan received after %.1f s (scan %d of %d, block %d of %d). '
-                    'The board is waiting for a trigger that is not arriving.'
-                    % (timeout_s, cur_sample.value + 1, self.settings.nos,
-                       cur_block.value + 1, self.settings.nob))
-            """ Yield the CPU: this loop used to spin flat out on one core while printing every
-            poll. """
-            time.sleep(0.001)
+    # This is the blocking call: it returns once the measurement is finished, so no data is read before it is all collected.
+    status = self.dll.DLLStartMeasurement_blocking()
+    if(status != 0):
+        raise RuntimeError(self.dll.DLLConvertErrorCodeToMsg(status))
 
     # This block is showing you how to get all data of the whole measurement with one DLL call
     data_buffer = (ctypes.c_uint16 * (self.settings.camera_settings[self.drvno].PIXEL * (self.settings.nos) * self.settings.camera_settings[self.drvno].CAMCNT * self.settings.nob))(0)

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -8,6 +8,7 @@ Created on Wed Jun  5 10:52:39 2024
 import ctypes
 import os
 import configparser
+import time
 import numpy as np
 
 # These are the settings structs. It must be the same like in EBST_CAM/shared_src/struct.h regarding order, data formats and size.
@@ -175,8 +176,27 @@ def init_measure(self):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
-def measure(self, use_blocking_call):
+def abort_measure(self):
+    """
+        Asks the board to drop a measurement that is still waiting for scans. Best effort: older DLL
+        builds do not export a stop function, in which case there is nothing to call.
+    """
+    try:
+        self.dll.DLLStopMeasurement(self.drvno)
+    except AttributeError:
+        pass
 
+
+def measure(self, use_blocking_call, timeout_s=None):
+    """
+        Runs one measurement and returns the spectrum averaged over samples and blocks.
+        input:
+            - use_blocking_call (bool): wait inside the DLL until every scan is collected. Only safe
+              when the scans are guaranteed to come, i.e. on the internal timer.
+            - timeout_s (float): non-blocking path only. Gives up after this many seconds if the
+              board is still waiting for scans, instead of hanging forever on a trigger that never
+              arrives. None waits indefinitely.
+    """
     # The sensor S14290 is a high speed sensor and is not completely cleared by one read out.
     # Therefore it may not be used without a reset signal, or following readouts have a crosstalk.
     status = self.dll.DLLCloseShutter(self.drvno)
@@ -189,7 +209,7 @@ def measure(self, use_blocking_call):
         if(status != 0):
             raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
     else:
-        # Start the measurement. This is the nonblocking call, which means it will return immediately. 
+        # Start the measurement. This is the nonblocking call, which means it will return immediately.
         self.dll.DLLStartMeasurement_nonblocking()
 
         cur_sample = ctypes.c_int64(-2)
@@ -197,9 +217,20 @@ def measure(self, use_blocking_call):
         cur_block = ctypes.c_int64(-2)
         ptr_cur_block = ctypes.pointer(cur_block)
 
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
         while cur_sample.value < self.settings.nos-1 or cur_block.value < self.settings.nob-1:
             self.dll.DLLGetCurrentScanNumber(self.drvno, ptr_cur_sample, ptr_cur_block)
-            print("sample: "+str(cur_sample.value)+" block: "+str(cur_block.value))
+            if deadline is not None and time.monotonic() > deadline:
+                abort_measure(self)
+                self.dll.DLLOpenShutter(self.drvno)
+                raise TimeoutError(
+                    'No scan received after %.1f s (scan %d of %d, block %d of %d). '
+                    'The board is waiting for a trigger that is not arriving.'
+                    % (timeout_s, cur_sample.value + 1, self.settings.nos,
+                       cur_block.value + 1, self.settings.nob))
+            """ Yield the CPU: this loop used to spin flat out on one core while printing every
+            poll. """
+            time.sleep(0.001)
 
     # This block is showing you how to get all data of the whole measurement with one DLL call
     data_buffer = (ctypes.c_uint16 * (self.settings.camera_settings[self.drvno].PIXEL * (self.settings.nos) * self.settings.camera_settings[self.drvno].CAMCNT * self.settings.nob))(0)

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -176,15 +176,22 @@ def init_measure(self):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
+def measurement_running(self):
+    """
+        Whether the board still considers a measurement to be in progress.
+    """
+    return bool(self.dll.DLLGetIsRunning())
+
+
 def abort_measure(self):
     """
-        Asks the board to drop a measurement that is still waiting for scans. Best effort: older DLL
-        builds do not export a stop function, in which case there is nothing to call.
+        Stops a measurement the board is still running.
+        The export is DLLAbortMeasurement. An earlier version of this called DLLStopMeasurement,
+        which this DLL does not export, and swallowed the resulting AttributeError: every timeout
+        therefore left the board running, and the next acquisition either failed with 'Measurement
+        is already running' or blocked with no way out.
     """
-    try:
-        self.dll.DLLStopMeasurement(self.drvno)
-    except AttributeError:
-        pass
+    self.dll.DLLAbortMeasurement()
 
 
 def measure(self, use_blocking_call, timeout_s=None):
@@ -197,6 +204,12 @@ def measure(self, use_blocking_call, timeout_s=None):
               board is still waiting for scans, instead of hanging forever on a trigger that never
               arrives. None waits indefinitely.
     """
+    """ Clear a measurement the board may still be running from a previous attempt. Without this an
+    acquisition that was aborted, timed out or killed leaves the board busy, and every later one
+    either fails with 'Measurement is already running' or never returns. """
+    if measurement_running(self):
+        abort_measure(self)
+
     # The sensor S14290 is a high speed sensor and is not completely cleared by one read out.
     # Therefore it may not be used without a reset signal, or following readouts have a crosstalk.
     status = self.dll.DLLCloseShutter(self.drvno)

--- a/src/main.py
+++ b/src/main.py
@@ -267,29 +267,7 @@ class MainInterface(QtWidgets.QMainWindow):
             item = QtWidgets.QTreeWidgetItem([device.capitalize()])
             self.parameter_tree.addTopLevelItem(item)
             for param in self.parameter_dic[device].keys():
-                child =QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
-                name_widget = QtWidgets.QLabel(param)
-                self.parameter_widgets[param] = QtWidgets.QDoubleSpinBox()
-                #self.parameter_widgets[param].setFixedSize(self.parameter_widgets[param].__sizeof__(), 16)
-                self.parameter_widgets[param].setReadOnly(self.parameter_dic[device][param]['read'])
-                try:
-                    self.parameter_widgets[param].setSuffix(self.parameter_dic[device][param]['unit'])
-                    self.parameter_widgets[param].setMaximum(self.parameter_dic[device][param]['max'])
-                except:
-                    pass
-                try:
-                    self.parameter_widgets[param].setMinimum(self.parameter_dic[device][param]['min'])
-                except:
-                    pass
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    self.parameter_widgets[param].setValue(self.parameter_dic[device][param]['val'])
-                    self.parameter_widgets[param].editingFinished.connect(partial(self.set_parameter,param))
-                    self.writeonly_parameter.append(param)
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, self.parameter_widgets[param])
+                self._build_parameter_tree_item(item, device, param)
 
         # start DataHandling
         # self.spec_length = self.devices['spectrometer'].get_num_pixel()
@@ -440,39 +418,53 @@ class MainInterface(QtWidgets.QMainWindow):
             self.parameter_tree.addTopLevelItem(item)
 
             for param in self.parameter_dic[device].keys():
-                child = QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
+                self._build_parameter_tree_item(item, device, param)
 
-                name_widget = QtWidgets.QLabel(param)
-                spin = QtWidgets.QDoubleSpinBox()
-                self.parameter_widgets[param] = spin
+    def _build_parameter_tree_item(self, item, device, param):
+        '''
+            Builds one row of the parameter tree (name label + value spinbox) for a
+            single device parameter and registers the resulting widget in
+            self.parameter_widgets/readonly_parameter/writeonly_parameter.
+            Cryostat parameters are always shown read-only here regardless of the
+            driver's 'read' flag: control of the cryostat must go through the
+            dedicated CryostatTab page. This tree only displays/logs its value.
+        '''
+        child = QtWidgets.QTreeWidgetItem()
+        item.addChild(child)
 
-                spin.setReadOnly(self.parameter_dic[device][param]['read'])
+        name_widget = QtWidgets.QLabel(param)
+        spin = QtWidgets.QDoubleSpinBox()
+        self.parameter_widgets[param] = spin
 
-                try:
-                    spin.setSuffix(self.parameter_dic[device][param]['unit'])
-                    spin.setMaximum(self.parameter_dic[device][param]['max'])
-                except Exception:
-                    pass
+        param_info = self.parameter_dic[device][param]
+        force_read_only = (device == 'cryostat')
+        spin.setReadOnly(param_info['read'] or force_read_only)
 
-                try:
-                    spin.setMinimum(self.parameter_dic[device][param]['min'])
-                except Exception:
-                    pass
+        try:
+            spin.setSuffix(param_info['unit'])
+            spin.setMaximum(param_info['max'])
+        except Exception:
+            pass
 
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    spin.setValue(self.parameter_dic[device][param]['val'])
-                    spin.editingFinished.connect(
-                        partial(self.set_parameter, param)
-                    )
-                    self.writeonly_parameter.append(param)
+        try:
+            spin.setMinimum(param_info['min'])
+        except Exception:
+            pass
 
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, spin)
+        if param_info['read']:
+            self.readonly_parameter.append(param)
+        elif force_read_only:
+            spin.setValue(param_info['val'])
+            self.readonly_parameter.append(param)
+        else:
+            spin.setValue(param_info['val'])
+            spin.editingFinished.connect(partial(self.set_parameter, param))
+            self.writeonly_parameter.append(param)
 
-    
+        self.parameter_tree.setItemWidget(child, 0, name_widget)
+        self.parameter_tree.setItemWidget(child, 1, spin)
+
+
 
     def update_read_parameter(self, new_parameter):
         for param in new_parameter.keys():

--- a/src/main.py
+++ b/src/main.py
@@ -393,6 +393,16 @@ class MainInterface(QtWidgets.QMainWindow):
         # Rebuild parameter tree UI (existing code)
         self.create_parameter_array()
 
+        self.parameter = {}
+        for device in self.parameter_dic:
+            for param in self.parameter_dic[device]:
+                self.parameter[param] = self.parameter_dic[device][param]['val']
+        self.DataHandling.close()
+        self.DataHandling = DataHandling(self.parameter, self.spec_length)
+        self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
+        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
+        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+
         logger.info(
             f"Switched to spectrometer: {new_name} "
             f"(spec_length={self.spec_length})"

--- a/src/main.py
+++ b/src/main.py
@@ -590,10 +590,10 @@ class MainInterface(QtWidgets.QMainWindow):
     def acquire_measurement(self):
         # take one spectrum with spectrometer
         if self.measurement_busy:
-            try:
-                self.measurement.take_spectrum()
-            except AttributeError:
-                logger.info('%s Measurement not started, devices are busy'%datetime.datetime.now())
+            """ take_spectrum() runs the blocking hardware readout, and this is the GUI thread: calling
+            it here froze the whole interface for as long as the camera took to answer. Let the running
+            measurement finish instead. """
+            logger.info('%s Measurement not started, devices are busy'%datetime.datetime.now())
         else:
             self.measurement_busy = True
             self.DataHandling.clear_data()

--- a/src/main.py
+++ b/src/main.py
@@ -485,6 +485,14 @@ class MainInterface(QtWidgets.QMainWindow):
                     # Si le paramètre est du texte (ex: "Stable"), on ignore l'erreur du spinbox
                     pass
 
+        """ Record the hardware state alongside the data. The Updater only carries the read-only
+        parameters, so it is merged over the settings held here to give the full picture. Nothing
+        called DataHandling.update_parameter() before, which is why saved files carried no hardware
+        settings at all. """
+        recorded = dict(self.parameter)
+        recorded.update(new_parameter)
+        self.DataHandling.update_parameter(recorded)
+
 
     def change_parameter(self, parameter, value):
         # change parameter when called from another script

--- a/src/main.py
+++ b/src/main.py
@@ -549,7 +549,12 @@ class MainInterface(QtWidgets.QMainWindow):
             wave = grp.attrs['xaxis']
 
         bg = data_set
-        self.DataHandling.background = bg[-self.spec_length:]
+        """ Routed through use_background() so the length is checked against the active spectrometer
+        and the background is marked as usable. Assigning the attribute directly left has_background
+        false, and a file of the wrong length was accepted without a word. """
+        if not self.DataHandling.use_background(bg):
+            self.bg_file_indicator.setText('rejected: wrong length')
+            return wave, bg
 
         # display measured spectra filepath
         idx = bg_path.rfind('/')
@@ -636,6 +641,10 @@ class MainInterface(QtWidgets.QMainWindow):
                                                      self.filename, self.comments_edit.toPlainText())
             self.measurement.sendProgress.connect(self.set_progress)
             self.measurement.sendSpectrum.connect(self.DataHandling.concatenate_data)
+            """ Without this the measured background was only ever stored as ordinary data: nothing
+            assigned DataHandling.background except loading a file, so acquiring a background and
+            ticking the correction box subtracted an uninitialised array. """
+            self.measurement.sendSpectrum.connect(self.DataHandling.set_background)
             self.measurement.sendSave.connect(self.DataHandling.save_data)
             self.measurement.start()
         else:

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -564,13 +564,60 @@ class FitTemporalBeamCalibration(QtCore.QThread):
         # Loop through each wavelength 
         max_chirp_values = []
         wavelength_values = []
-        for wls in range(self.data.shape[1]):
-            intensity_column = self.data[:, wls]
-            max_row_index = np.argmax(intensity_column)
-            if max_row_index == 0:
-                continue
-            max_chirp_values.append(self.chirp_array[max_row_index])
-            wavelength_values.append(self.wavelength_array[wls])
+        # for wls in range(self.data.shape[1]):
+        #     intensity_column = self.data[:, wls]
+        #     max_row_index = np.argmax(intensity_column)
+        #     if max_row_index == 0:
+        #         continue
+        #     max_chirp_values.append(self.chirp_array[max_row_index])
+        #     wavelength_values.append(self.wavelength_array[wls])
+
+
+        # ----- Find starting wavelength -----
+        # wavelength with the strongest overall signal
+        start_col = np.argmax(np.max(self.data, axis=0))
+
+        # maximum there
+        start_row = np.argmax(self.data[:, start_col])
+
+        indices = np.zeros(self.data.shape[1], dtype=int)
+        indices[start_col] = start_row
+
+        # Search window in chirp units
+        window = 1000   # fs²/rad²
+
+        dchirp = np.abs(self.chirp_array[1] - self.chirp_array[0])
+        N = int(window / dchirp)
+
+        # ---------- Track toward longer wavelengths ----------
+        for col in range(start_col + 1, self.data.shape[1]):
+
+            prev = indices[col-1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # ---------- Track toward shorter wavelengths ----------
+        for col in range(start_col-1, -1, -1):
+
+            prev = indices[col+1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # Final arrays
+        max_chirp_values = self.chirp_array[indices]
+        wavelength_values = self.wavelength_array
+
+
         max_chirp_values = np.array(max_chirp_values)
         wavelength_values = np.array(wavelength_values)
         omega_values = 0.5*co.waveToAngFreq(np.array(wavelength_values) * 1e-9) # rad Hz

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -85,7 +85,7 @@ class VerticalBeamCalibrationMeasurement(QtCore.QThread):
                 self.vertical_calibration_data['intensities']=self.intensities
                 self.vertical_calibration_data['rows']=self.rows
                 if i>=1:
-                    self.send_intensities.emit(self.rows,self.intensities[1:])
+                    self.send_intensities.emit(self.rows,self.intensities)
         self.vertical_calibration_data['intensities']=self.intensities
         self.vertical_calibration_data['rows']=self.rows
         self.send_vertical_calibration_data.emit(('vertical_calibration_data',self.vertical_calibration_data))
@@ -423,11 +423,12 @@ class ChirpCalibrationMeasurement(QtCore.QThread):
                                 'data' : np.array(self.intensities)
                                 }
                             if i>=3:
-                                indexes = np.where(
-                                    (self.wls >= (self.carrierWls/2 - 100)) &
-                                    (self.wls <= (self.carrierWls/2 + 100))
-                                )[0]
-                                self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                # indexes = np.where(
+                                #     (self.wls >= (self.carrierWls/2 - 100)) &
+                                #     (self.wls <= (self.carrierWls/2 + 100))
+                                # )[0]
+                                # self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                self.send_chirp.emit(self.chirp[3:i],self.wls,np.array(self.intensities)[3:i,:])
         self.send_chirp_calibration_data.emit(('chirp_calibration_raw_data',self.Chirp_calibration_data))
         self.sendProgress.emit(100)
         self.stop()
@@ -775,6 +776,7 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         data_filtered_region = data_filtered[1:-1, mask]
         data_integrated = np.sum(data_filtered_region, axis=1)
         data_integrated_normalized = data_integrated/np.max(data_integrated)
+        data_integrated_normalized = -(data_integrated_normalized-np.max(data_integrated_normalized))
 
         self.sendCrossCorrelationRegion.emit(delay_array_region, data_integrated_normalized)
         self.delay_calibration_processed_data={
@@ -799,7 +801,8 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         C0 = np.min(self.intensity)
 
         p0 = [A0, mu0, sigma0, C0]
-        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0)
+        bounds = ([-np.inf, self.delay.min(), 0, -np.inf], [ np.inf, self.delay.max(), np.inf, np.inf])
+        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0, bounds=bounds)
         A, mu, sigma, C = popt
         self.fitted_intensity = (A * np.exp(-(self.delay - mu)**2 / (2 * sigma**2)) + C)
         self.sendCrossCorrelationRegionFit.emit(self.delay, self.fitted_intensity, mu, sigma)

--- a/src/measurements/MDCSClasses.py
+++ b/src/measurements/MDCSClasses.py
@@ -191,20 +191,20 @@ class BoxcarGeometry(QtCore.QThread):
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
                 'C' : self.t_secondary[i]*np.ones(Nb_step),
-                'B' : self.t_scanned,
+                'B' : self.t_scanned.copy(),
                 'LO' : self.t_scanned-self.t_LO*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - rephasing':
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
-                'C' : self.t_scanned,
+                'C' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - non rephasing':
             self.group_delay = {
                 'C' : np.zeros(Nb_step),
-                'A' : self.t_scanned,
+                'A' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
@@ -215,6 +215,17 @@ class BoxcarGeometry(QtCore.QThread):
                 'A' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
+        elif self.measurement_type == 'LO scan':
+            self.group_delay = {
+                'C' : np.zeros(Nb_step),
+                'B' : np.zeros(Nb_step),
+                'A' : np.zeros(Nb_step),
+                'LO' : self.t_scanned.copy()
+            }
+        
+        # To give the right delay between pulse
+        for key in self.group_delay:
+            self.group_delay[key] *= -1
 
     def phase_cycling(self, j):
         '''

--- a/src/measurements/MeasurementClasses.py
+++ b/src/measurements/MeasurementClasses.py
@@ -28,11 +28,18 @@ class AcquireMeasurement(QtCore.QThread):
 
     def run(self):
         logger.info(time.strftime('%H:%M:%S') + ' Begin single spectrum acquisition')
-        if not self.terminate:  # check whether stopping measurement is called
-            self.sendProgress.emit(50)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.take_spectrum()
-            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        try:
+            if not self.terminate:  # check whether stopping measurement is called
+                self.sendProgress.emit(50)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.take_spectrum()
+                logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Single spectrum acquisition failed')
+        finally:
+            """ Progress 100 is what releases measurement_busy in the main window. Emitting it here
+            rather than only on success means a failed or stopped measurement no longer leaves the
+            interface stuck on "devices are busy" until the software is restarted. """
             self.sendProgress.emit(100)
 
     def take_spectrum(self):
@@ -59,21 +66,25 @@ class ViewMeasurement(QtCore.QThread):
         self.terminate = False
 
     def run(self):
-        while not self.terminate:  # check whether stopping measurement is called
-            t = time.time()
-            self.sendProgress.emit(50)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.spec = np.array(self.spectrometer.get_intensities())
-            self.sendClear.emit()
-            self.sendSpectrum.emit(self.wls, self.spec)
+        try:
+            while not self.terminate:  # check whether stopping measurement is called
+                t = time.time()
+                self.sendProgress.emit(50)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.spec = np.array(self.spectrometer.get_intensities())
+                self.sendClear.emit()
+                self.sendSpectrum.emit(self.wls, self.spec)
 
-            # limit too fast acquistion for computation
-            if time.time() - t < 0.02:
-                time.sleep(0.02)
+                # limit too fast acquistion for computation
+                if time.time() - t < 0.02:
+                    time.sleep(0.02)
 
-        # Finish measurement when loop is terminated
-        logger.info(time.strftime('%H:%M:%S') + ' Finished')
-        self.sendProgress.emit(100)
+            # Finish measurement when loop is terminated
+            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Continuous view failed')
+        finally:
+            self.sendProgress.emit(100)
 
     def stop(self):
         self.terminate = True
@@ -95,21 +106,25 @@ class RunMeasurement(QtCore.QThread):
 
     def run(self):
         logger.info(time.strftime('%H:%M:%S') + ' Begin continuous acquisition')
-        while not self.terminate:  # loop runs until requested stop
-            t1 = time.time()
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.spec = np.array(self.spectrometer.get_intensities())
+        try:
+            while not self.terminate:  # loop runs until requested stop
+                t1 = time.time()
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.spec = np.array(self.spectrometer.get_intensities())
 
-            # send data
-            self.sendSpectrum.emit(self.wls, self.spec)
-            progress = 50
-            self.sendProgress.emit(progress)
+                # send data
+                self.sendSpectrum.emit(self.wls, self.spec)
+                progress = 50
+                self.sendProgress.emit(progress)
 
-            # limit too fast acquistion for computation
-            if time.time() - t1 < 0.02:
-                time.sleep(0.02)
-        logger.info(time.strftime('%H:%M:%S') + ' Finished')
-        self.sendProgress.emit(100)
+                # limit too fast acquistion for computation
+                if time.time() - t1 < 0.02:
+                    time.sleep(0.02)
+            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Continuous acquisition failed')
+        finally:
+            self.sendProgress.emit(100)
         return
 
     #  initiate controlled stop by enableing terminate statement, that is frequently queried in run code
@@ -136,23 +151,27 @@ class BackgroundMeasurement(QtCore.QThread):
         self.terminate = False
 
     def run(self):
-        if not self.terminate:  # check whether stopping measurement is called
-            """ Wavelengths are read once, before the loop. They used to be assigned only inside it,
-            so a background of a single scan emitted an empty array and broke the receiving slot.
-            scans is clamped because its spin box declares no minimum and so allows 0, which also
-            divided by zero below. """
-            scans = max(int(self.scans), 1)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.summedspec = np.array(self.spectrometer.get_intensities())
-            for i in range(scans - 1):
-                self.sendProgress.emit((i + 1) / scans * 100)
-                self.spec = np.array(self.spectrometer.get_intensities())
-                self.summedspec = self.summedspec + self.spec
-            self.spec = self.summedspec / scans
-            self.sendSpectrum.emit(self.wls, self.spec)
-            self.sendSave.emit(self.filename, self.comments)
+        try:
+            if not self.terminate:  # check whether stopping measurement is called
+                """ Wavelengths are read once, before the loop. They used to be assigned only inside
+                it, so a background of a single scan emitted an empty array and broke the receiving
+                slot. scans is clamped because its spin box declares no minimum and so allows 0,
+                which also divided by zero below. """
+                scans = max(int(self.scans), 1)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.summedspec = np.array(self.spectrometer.get_intensities())
+                for i in range(scans - 1):
+                    self.sendProgress.emit((i + 1) / scans * 100)
+                    self.spec = np.array(self.spectrometer.get_intensities())
+                    self.summedspec = self.summedspec + self.spec
+                self.spec = self.summedspec / scans
+                self.sendSpectrum.emit(self.wls, self.spec)
+                self.sendSave.emit(self.filename, self.comments)
+                logger.info(time.strftime('%H:%M:%S') + 'Background acquired')
+        except Exception:
+            logger.exception('Background acquisition failed')
+        finally:
             self.sendProgress.emit(100)
-            logger.info(time.strftime('%H:%M:%S') + 'Background acquired')
 
     def stop(self):
         self.terminate = True

--- a/src/measurements/MeasurementClasses.py
+++ b/src/measurements/MeasurementClasses.py
@@ -137,13 +137,18 @@ class BackgroundMeasurement(QtCore.QThread):
 
     def run(self):
         if not self.terminate:  # check whether stopping measurement is called
+            """ Wavelengths are read once, before the loop. They used to be assigned only inside it,
+            so a background of a single scan emitted an empty array and broke the receiving slot.
+            scans is clamped because its spin box declares no minimum and so allows 0, which also
+            divided by zero below. """
+            scans = max(int(self.scans), 1)
+            self.wls = np.array(self.spectrometer.get_wavelength())
             self.summedspec = np.array(self.spectrometer.get_intensities())
-            for i in range(self.scans - 1):
-                self.sendProgress.emit((i + 1) / self.scans * 100)
-                self.wls = np.array(self.spectrometer.get_wavelength())
+            for i in range(scans - 1):
+                self.sendProgress.emit((i + 1) / scans * 100)
                 self.spec = np.array(self.spectrometer.get_intensities())
                 self.summedspec = self.summedspec + self.spec
-            self.spec = self.summedspec / self.scans
+            self.spec = self.summedspec / scans
             self.sendSpectrum.emit(self.wls, self.spec)
             self.sendSave.emit(self.filename, self.comments)
             self.sendProgress.emit(100)


### PR DESCRIPTION
## Summary
Bundle of DAQ reliability fixes found during a targeted bug hunt, all previously silent failures:
- Spectra never reached the plot (silent IndexError on empty parameter deques).
- A blocking camera read could freeze the GUI thread indefinitely.
- The Stresing worker was bypassed entirely; trigger registers replaced with a derived mode; `measure()` given a timeout.
- Background correction was subtracting uninitialized memory.
- Hardware parameters were never recorded; `measurement_busy` could get stuck after an exception; `save_data()` could copy a half-written file.
- `abort_measure()` called a DLL function that doesn't exist on this board, leaving measurements stuck after every timeout.
- Also adds `.gitattributes` to stop git corrupting binaries (PDF/DLL/.h5) via line-ending conversion.

## Test plan
- Measured against the physical Stresing board where noted in individual commit messages.