### PR TITLE
Fix/pixis vertical binning

### DIFF
--- a/manual/camera_spectrometer.md
+++ b/manual/camera_spectrometer.md
@@ -1,0 +1,5 @@
+# Camera and spectrometer
+
+Colbert can be used with two cameras (Stresing and Pixis) plugged to one spoectrometer. Everything is managed in the intruments.py where you can add or removed devices. The spectrometer is the main device where the cameras could be attached, meaning that all camera parameters are child of the parent spectrometer. Those parameters are all saved and managed through Data Handling. 
+
+On the main panel, on the top right, you can find a sliding menu where there is a list of the connected cameras. Selecting another camera reset completely Data Handling beacause the number of parameter is changing between cameras and also the length of the sensor may be different. For those reasons, it is easier to reset. All the other calibrations that were not associated with the camera will be loaded back. However, the connection between the beam explorer and Data Handling seems to be lost. 

--- a/samples/drivers/pixis_vertical_profile_diagnostic.py
+++ b/samples/drivers/pixis_vertical_profile_diagnostic.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+"""
+Standalone diagnostic for the PIXIS vertical readout.
+
+The PIXIS is a 2D sensor (1024 columns x ~256 rows). On a spectrograph the horizontal axis is
+wavelength and the vertical axis is position along the entrance slit, so the signal only occupies
+the rows where the beam is imaged. Reading a single row samples one height in the slit and throws
+away everything else.
+
+This script reads one full frame, shows where the signal actually sits vertically, and reports how
+much signal a single-row readout would miss. Use the y0/height it suggests with
+Pixis.set_binned_roi(y0, height).
+
+Runs on its own, outside the COLBERTo interface, and changes nothing in the repository.
+Requires pylablib and a connected camera. Matplotlib is optional (text output works without it).
+
+    python samples/drivers/pixis_vertical_profile_diagnostic.py
+    python samples/drivers/pixis_vertical_profile_diagnostic.py --exposure 200 --frames 5
+"""
+
+import argparse
+import sys
+import time
+
+import numpy as np
+
+
+def acquire_full_frame(exposure_ms, n_frames):
+    """
+        Connects to the PIXIS, forces a full-frame unbinned readout and averages a few frames.
+        input:
+            - exposure_ms (float): exposure time in ms
+            - n_frames (int): number of frames to average
+        output:
+            - np.ndarray: 2D frame (rows x columns), averaged over n_frames
+    """
+    from pylablib.devices import PrincetonInstruments
+
+    print('Cameras found:', PrincetonInstruments.list_cameras())
+    camera = PrincetonInstruments.PicamCamera()
+    print('Camera connected')
+
+    try:
+        width, height = camera.get_detector_size()
+    except Exception as e:
+        width, height = 1024, 256
+        print(f'Could not query detector size, assuming {width}x{height}. {e}')
+    print(f'Sensor: {width} columns x {height} rows')
+
+    # Full frame, no binning: every row read separately.
+    roi = {"x": 0, "width": width, "x_binning": 1, "y": 0, "height": height, "y_binning": 1}
+    camera.set_attribute_value("ROIs", [roi])
+    camera.set_attribute_value("Exposure Time", int(exposure_ms))
+
+    camera.start_acquisition()
+    frames = []
+    try:
+        for i in range(n_frames):
+            frame = None
+            deadline = time.time() + exposure_ms / 1e3 + 5.0
+            while frame is None and time.time() < deadline:
+                time.sleep(0.02)
+                frame = camera.read_newest_image()
+            if frame is None:
+                print(f'  frame {i + 1}/{n_frames}: timeout, skipped')
+                continue
+            frames.append(np.asarray(frame, dtype=float))
+            print(f'  frame {i + 1}/{n_frames}: shape {np.shape(frame)}')
+    finally:
+        camera.stop_acquisition()
+        try:
+            camera.close()
+        except Exception:
+            pass
+
+    if not frames:
+        raise RuntimeError('No frame acquired. Check exposure time and that light reaches the camera.')
+    return np.mean(frames, axis=0)
+
+
+def analyse(frame, floor_fraction=0.1):
+    """
+        Locates the signal band along the vertical axis and quantifies what a single-row readout loses.
+        input:
+            - frame (np.ndarray): 2D frame (rows x columns)
+            - floor_fraction (float): fraction of the peak above baseline used to delimit the band
+        output:
+            - dict: analysis results, including the suggested y0 and height
+    """
+    frame = np.asarray(frame, dtype=float)
+    if frame.ndim != 2:
+        raise ValueError(f'Expected a 2D frame, got shape {frame.shape}. '
+                         'The ROI was probably not applied.')
+
+    n_rows = frame.shape[0]
+    profile = frame.sum(axis=1)                      # total counts per sensor row
+
+    baseline = np.median(profile)
+    contrast = profile - baseline
+    peak_row = int(np.argmax(contrast))
+    peak_value = contrast[peak_row]
+
+    if peak_value <= 0:
+        return dict(n_rows=n_rows, profile=profile, baseline=baseline, peak_row=peak_row,
+                    signal_rows=np.array([], dtype=int), y0=0, height=n_rows,
+                    flat=True, total=float(profile.sum()), row0=float(profile[0]),
+                    band=float('nan'), gain_vs_row0=float('nan'))
+
+    # Rows carrying a meaningful share of the peak define the band worth binning.
+    signal_rows = np.where(contrast >= floor_fraction * peak_value)[0]
+    y0, y1 = int(signal_rows.min()), int(signal_rows.max())
+    height = y1 - y0 + 1
+
+    band = float(profile[y0:y1 + 1].sum())
+    row0 = float(profile[0])
+    total = float(profile.sum())
+
+    return dict(n_rows=n_rows, profile=profile, baseline=float(baseline), peak_row=peak_row,
+                signal_rows=signal_rows, y0=y0, height=height, flat=False,
+                total=total, row0=row0, band=band,
+                gain_vs_row0=(band / row0 if row0 > 0 else float('inf')))
+
+
+def report(res):
+    """
+        Prints the verdict in plain terms.
+        input:
+            - res (dict): output of analyse()
+    """
+    print('\n' + '=' * 64)
+    print('VERTICAL PROFILE')
+    print('=' * 64)
+    print(f'Sensor rows read      : {res["n_rows"]}')
+
+    if res['flat']:
+        print('\nNo vertical structure found: the profile is flat.')
+        print('Either no light is reaching the camera, or the ROI was not applied.')
+        print('Check the shape printed above: a single row means the camera cropped the readout.')
+        return
+
+    print(f'Baseline (median row) : {res["baseline"]:.1f} counts')
+    print(f'Brightest row         : {res["peak_row"]}')
+    print(f'Signal band           : rows {res["y0"]} to {res["y0"] + res["height"] - 1} '
+          f'({res["height"]} rows)')
+    print()
+    print(f'Counts in row 0 alone : {res["row0"]:.4g}   <- what the interface reads today')
+    print(f'Counts in signal band : {res["band"]:.4g}')
+    print(f'Counts in whole frame : {res["total"]:.4g}')
+    print()
+
+    gain = res['gain_vs_row0']
+    if np.isfinite(gain):
+        print(f'Binning the band collects {gain:.1f}x more signal than row 0 alone.')
+    else:
+        print('Row 0 collects essentially nothing: the signal is elsewhere on the sensor.')
+
+    if res['peak_row'] > 5:
+        print(f'\nThe signal is centred on row {res["peak_row"]}, not row 0, so a single-row readout')
+        print('at y=0 is reading off the beam entirely.')
+
+    print('\nSuggested measurement setting:')
+    print(f'    spectrometer.set_binned_roi(y0={res["y0"]}, height={res["height"]})')
+    print('\nOn chip binning also sums the charge before the readout amplifier, so the read noise is')
+    print('paid once rather than once per row. The signal-to-noise gain is larger than the count')
+    print('ratio above whenever the measurement is read-noise limited.')
+
+
+def plot(frame, res):
+    """
+        Optional visual check: the frame and its vertical profile.
+        input:
+            - frame (np.ndarray): 2D frame
+            - res (dict): output of analyse()
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print('\n(matplotlib not available, skipping the plot)')
+        return
+
+    fig, (ax_img, ax_prof) = plt.subplots(1, 2, figsize=(12, 4.5),
+                                          gridspec_kw={'width_ratios': [2, 1]})
+    ax_img.imshow(frame, aspect='auto', origin='lower', interpolation='nearest')
+    ax_img.set_xlabel('Column (wavelength)')
+    ax_img.set_ylabel('Row (position along slit)')
+    ax_img.set_title('Full frame')
+
+    ax_prof.plot(res['profile'], np.arange(res['n_rows']))
+    if not res['flat']:
+        ax_prof.axhspan(res['y0'], res['y0'] + res['height'] - 1, alpha=0.25,
+                        label=f'band: y0={res["y0"]}, h={res["height"]}')
+        ax_prof.axhline(0, linestyle='--', linewidth=1, label='row 0 (read today)')
+        ax_prof.legend(loc='best', fontsize=8)
+    ax_prof.set_xlabel('Counts summed over wavelength')
+    ax_prof.set_title('Vertical profile')
+
+    fig.tight_layout()
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--exposure', type=float, default=100.0, help='exposure time in ms')
+    parser.add_argument('--frames', type=int, default=3, help='frames to average')
+    parser.add_argument('--floor', type=float, default=0.1,
+                        help='fraction of peak above baseline delimiting the signal band')
+    parser.add_argument('--no-plot', action='store_true', help='text output only')
+    parser.add_argument('--save', type=str, default=None, help='save the frame to this .npy file')
+    args = parser.parse_args()
+
+    try:
+        frame = acquire_full_frame(args.exposure, args.frames)
+    except Exception as e:
+        print(f'\nAcquisition failed: {e}')
+        return 1
+
+    if args.save:
+        np.save(args.save, frame)
+        print(f'Frame saved to {args.save}')
+
+    res = analyse(frame, floor_fraction=args.floor)
+    report(res)
+    if not args.no_plot:
+        plot(frame, res)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -91,8 +91,12 @@ class DataHandling(QtCore.QThread):
         hardware parameter is added to the deque"""
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
+
         for idx, param in enumerate(self.parameter):
             self.parameter_queue[param].append(parameter[idx])
+
+        # for param, value in zip(self.parameter_queue, parameter):
+        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -308,7 +312,10 @@ class DataHandling(QtCore.QThread):
         Parameters:
             new_length (int): The new number of pixels in the spectrum.
         """
-        self.speclength = new_length
+        if isinstance(new_length, tuple):
+            self.speclength = new_length[1]  # or [0], whichever is intended
+        else:
+            self.speclength = new_length
 
         # Reset spectrum buffer
         self.spec = np.zeros((self.speclength, 0))  # zero columns, rows = new_length
@@ -331,6 +338,47 @@ class DataHandling(QtCore.QThread):
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")
+
+    def close(self):
+        """Safely stop Qt thread + worker before re-instantiating DataHandling."""
+
+        # 1. Stop worker thread safely (if it has a stop flag)
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.terminate = True  # your custom flag (optional)
+        except:
+            pass
+
+        # 2. Disconnect signals (VERY important)
+        try:
+            if hasattr(self, "bufferSaveSignal"):
+                self.bufferSaveSignal.disconnect()
+        except:
+            pass
+
+        # 3. Quit Qt thread event loop
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.quit()
+                self.thread.wait()   # blocks until fully stopped
+        except:
+            pass
+
+        # 4. Delete worker safely
+        try:
+            if hasattr(self, "BufferWorker") and self.BufferWorker is not None:
+                self.BufferWorker.deleteLater()
+                self.BufferWorker = None
+        except:
+            pass
+
+        # 5. Delete thread safely
+        try:
+            if hasattr(self, "thread") and self.thread is not None:
+                self.thread.deleteLater()
+                self.thread = None
+        except:
+            pass
 
 
 class BufferWorker(QtCore.QObject):

--- a/src/GUI/BeamExplorer.py
+++ b/src/GUI/BeamExplorer.py
@@ -188,7 +188,7 @@ class BeamWidget(QWidget):
 
     def set_phase_manually(self):
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
     def toggle_beam_to_slm(self):
         '''
@@ -217,7 +217,7 @@ class BeamWidget(QWidget):
         self.beam.set_beamVerticalDelimiters([int(self.delimiter_table.item(0,0).text()),int(self.delimiter_table.item(0,1).text())])
         self.beam.set_beamHorizontalDelimiters([int(self.delimiter_table.item(1,0).text()),int(self.delimiter_table.item(1,1).text())])
         self.beam.set_optimalPhase(P([float(self.phase_coeff_table.item(0,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(0,i) is not None]))
-        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]))
+        self.beam.set_currentPhase(P([float(self.phase_coeff_table.item(1,i).text()) for i in range(self.phase_coeff_table.columnCount()) if self.phase_coeff_table.item(1,i) is not None]), mode='absolute')
 
         return self.name,self.beam
 

--- a/src/GUI/CameraDisplay.py
+++ b/src/GUI/CameraDisplay.py
@@ -1,0 +1,274 @@
+"""
+Live 2D view of a spectrograph camera, with the vertical readout controls next to it.
+
+On a spectrograph the horizontal axis of the sensor is wavelength and the vertical axis is position
+along the entrance slit, so the signal only occupies the rows where the beam is imaged. This widget
+shows where that band actually sits and lets the readout region be set accordingly.
+
+Two modes:
+    - Full frame: every sensor row read separately. Slower and noisier per row, used for alignment.
+    - Binned: the selected rows are summed on chip into a single row. The read noise is paid once
+      instead of once per row, which is what makes weak signals usable for measurements.
+
+Fed straight from the camera worker, deliberately bypassing DataHandling: this is a live diagnostic
+view, not measurement data, so it does not go through the 1D acquisition and storage chain.
+"""
+
+from PyQt5 import QtWidgets, QtCore
+import pyqtgraph as pg
+import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CameraDisplay(QtWidgets.QWidget):
+    """
+        Displays the live camera frame and its vertical profile, and applies the readout region.
+    """
+
+    roi_applied = QtCore.pyqtSignal(int, int)  # y0, height
+
+    def __init__(self, spectrometer=None, parent=None):
+        """
+            Builds the camera view.
+            input:
+                - spectrometer: a camera driver exposing set_full_frame/set_binned_roi/get_roi
+                  (currently Pixis). None leaves the controls disabled until set_spectrometer is called.
+                - parent: parent widget
+        """
+        super(CameraDisplay, self).__init__(parent)
+        self.spectrometer = None
+        self.last_frame = None
+        self._auto_levels_pending = True
+
+        # ---- image ----
+        self.graphLayoutWidget = pg.GraphicsLayoutWidget()
+        self.plot = self.graphLayoutWidget.addPlot()
+        self.plot.setLabel('bottom', 'Column (wavelength)')
+        self.plot.setLabel('left', 'Row (position along slit)')
+        self.image = pg.ImageItem(axisOrder='row-major')
+        self.plot.addItem(self.image)
+        self.histogram = pg.HistogramLUTItem()
+        self.histogram.setImageItem(self.image)
+        self.graphLayoutWidget.addItem(self.histogram)
+
+        # Lines marking the region that will be binned
+        self.region = pg.LinearRegionItem(orientation='horizontal', movable=True)
+        self.region.setZValue(10)
+        self.plot.addItem(self.region)
+        self.region.sigRegionChangeFinished.connect(self.region_dragged)
+
+        # ---- vertical profile ----
+        self.profile_plot = pg.PlotWidget()
+        self.profile_plot.setLabel('bottom', 'Counts (summed over wavelength)')
+        self.profile_plot.setLabel('left', 'Row')
+        self.profile_plot.setMaximumWidth(260)
+        self.profile_curve = self.profile_plot.plot([], [])
+
+        # ---- controls ----
+        self.mode_full_frame = QtWidgets.QRadioButton('Full frame (alignment)')
+        self.mode_binned = QtWidgets.QRadioButton('Binned (measurement)')
+        self.mode_full_frame.setChecked(True)
+        self.y0_spin = QtWidgets.QSpinBox()
+        self.y0_spin.setRange(0, 4096)
+        self.height_spin = QtWidgets.QSpinBox()
+        self.height_spin.setRange(1, 4096)
+        self.height_spin.setValue(1)
+        self.auto_button = QtWidgets.QPushButton('Find signal band')
+        self.apply_button = QtWidgets.QPushButton('Apply readout region')
+        self.status_label = QtWidgets.QLabel('No frame received yet.')
+        self.status_label.setWordWrap(True)
+
+        controls = QtWidgets.QHBoxLayout()
+        mode_box = QtWidgets.QGroupBox('Readout mode')
+        mode_layout = QtWidgets.QVBoxLayout()
+        mode_layout.addWidget(self.mode_full_frame)
+        mode_layout.addWidget(self.mode_binned)
+        mode_box.setLayout(mode_layout)
+        controls.addWidget(mode_box)
+
+        region_box = QtWidgets.QGroupBox('Rows to bin')
+        region_layout = QtWidgets.QHBoxLayout()
+        region_layout.addWidget(QtWidgets.QLabel('First row:'))
+        region_layout.addWidget(self.y0_spin)
+        region_layout.addWidget(QtWidgets.QLabel('Number of rows:'))
+        region_layout.addWidget(self.height_spin)
+        region_layout.addWidget(self.auto_button)
+        region_layout.addWidget(self.apply_button)
+        region_box.setLayout(region_layout)
+        controls.addWidget(region_box, stretch=1)
+
+        graphs = QtWidgets.QHBoxLayout()
+        graphs.addWidget(self.graphLayoutWidget, stretch=1)
+        graphs.addWidget(self.profile_plot)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(controls)
+        layout.addLayout(graphs, stretch=1)
+        layout.addWidget(self.status_label)
+        self.setLayout(layout)
+
+        # ---- connections ----
+        self.mode_full_frame.toggled.connect(self.mode_changed)
+        self.auto_button.clicked.connect(self.find_signal_band)
+        self.apply_button.clicked.connect(self.apply_roi)
+        self.y0_spin.valueChanged.connect(self.spins_changed)
+        self.height_spin.valueChanged.connect(self.spins_changed)
+
+        self.set_spectrometer(spectrometer)
+
+    def set_spectrometer(self, spectrometer):
+        """
+            Attaches the camera whose readout region this widget controls.
+            input:
+                - spectrometer: camera driver, or None to disable the controls
+        """
+        self.spectrometer = spectrometer
+        supported = spectrometer is not None and hasattr(spectrometer, 'set_binned_roi')
+        for widget in (self.mode_full_frame, self.mode_binned, self.y0_spin,
+                       self.height_spin, self.auto_button, self.apply_button):
+            widget.setEnabled(supported)
+        if not supported:
+            self.status_label.setText(
+                'Active spectrometer does not expose a configurable readout region. '
+                'This view only applies to the Pixis camera.')
+            return
+
+        sensor_height = int(getattr(spectrometer, 'sensor_height', 256))
+        self.y0_spin.setRange(0, max(sensor_height - 1, 0))
+        self.height_spin.setRange(1, sensor_height)
+        try:
+            y0, height, binning = spectrometer.get_roi()
+            self.y0_spin.setValue(y0)
+            self.height_spin.setValue(height)
+            self.mode_binned.setChecked(binning > 1)
+            self.mode_full_frame.setChecked(binning == 1)
+        except Exception as e:
+            logger.warning('Could not read current Pixis ROI: %s', e)
+        self.update_region_from_spins()
+
+    @QtCore.pyqtSlot(np.ndarray, float)
+    def set_data(self, frame, int_time=None):
+        """
+            Receives a frame from the camera worker and refreshes the view.
+            input:
+                - frame (np.ndarray): 1D or 2D camera frame
+                - int_time (float): integration time, accepted so this can connect directly to the
+                  worker's sendSpectrum signal. Unused.
+        """
+        frame = np.asarray(frame, dtype=float)
+        if frame.ndim == 1:
+            frame = frame[np.newaxis, :]
+        if frame.size == 0:
+            return
+        self.last_frame = frame
+
+        self.image.setImage(frame, autoLevels=self._auto_levels_pending)
+        if self._auto_levels_pending:
+            self.histogram.setLevels(*self.image.getLevels())
+            self._auto_levels_pending = False
+
+        profile = frame.sum(axis=1)
+        rows = np.arange(frame.shape[0])
+        self.profile_curve.setData(profile, rows)
+
+        if frame.shape[0] == 1:
+            self.status_label.setText(
+                'Camera is returning a single row: the readout is binned or cropped. '
+                'Switch to full frame to see where the signal sits on the sensor.')
+        else:
+            peak = int(np.argmax(profile - np.median(profile)))
+            self.status_label.setText(
+                f'Frame {frame.shape[0]} rows x {frame.shape[1]} columns. '
+                f'Brightest row: {peak}. Max: {frame.max():.0f} counts.')
+
+    def find_signal_band(self, floor_fraction=0.1):
+        """
+            Sets the row controls from the vertical profile of the last full frame received.
+            input:
+                - floor_fraction (float): fraction of the peak above baseline delimiting the band
+        """
+        if self.last_frame is None or self.last_frame.shape[0] < 2:
+            self.status_label.setText(
+                'Need a full frame first. Select "Full frame" and acquire, then try again.')
+            return
+
+        profile = self.last_frame.sum(axis=1)
+        contrast = profile - np.median(profile)
+        peak_value = contrast.max()
+        if peak_value <= 0:
+            self.status_label.setText('No vertical structure found: is any light reaching the camera?')
+            return
+
+        rows = np.where(contrast >= floor_fraction * peak_value)[0]
+        y0, height = int(rows.min()), int(rows.max() - rows.min() + 1)
+        self.y0_spin.setValue(y0)
+        self.height_spin.setValue(height)
+
+        band = float(profile[y0:y0 + height].sum())
+        row0 = float(profile[0])
+        gain = band / row0 if row0 > 0 else float('inf')
+        self.status_label.setText(
+            f'Signal band: rows {y0} to {y0 + height - 1} ({height} rows). '
+            f'Binning it collects {gain:.1f}x more signal than row 0 alone.')
+
+    def apply_roi(self):
+        """
+            Applies the selected readout mode and region to the camera.
+        """
+        if self.spectrometer is None or not hasattr(self.spectrometer, 'set_binned_roi'):
+            return
+        try:
+            if self.mode_full_frame.isChecked():
+                self.spectrometer.set_full_frame()
+                self.status_label.setText('Full frame readout applied (alignment mode).')
+            else:
+                y0, height = self.y0_spin.value(), self.height_spin.value()
+                self.spectrometer.set_binned_roi(y0, height)
+                self.status_label.setText(
+                    f'Binned readout applied: rows {y0} to {y0 + height - 1} summed on chip.')
+                self.roi_applied.emit(y0, height)
+            self._auto_levels_pending = True
+        except Exception as e:
+            logger.error('Failed to apply Pixis ROI: %s', e)
+            self.status_label.setText(f'Could not apply readout region: {e}')
+
+    def mode_changed(self):
+        """
+            Enables the row controls only in binned mode.
+        """
+        binned = self.mode_binned.isChecked()
+        for widget in (self.y0_spin, self.height_spin):
+            widget.setEnabled(binned)
+        self.region.setVisible(binned)
+
+    def spins_changed(self):
+        """
+            Keeps the region overlay in step with the spin boxes.
+        """
+        self.update_region_from_spins()
+
+    def update_region_from_spins(self):
+        """
+            Redraws the region overlay from the current row controls.
+        """
+        y0 = self.y0_spin.value()
+        height = self.height_spin.value()
+        self.region.blockSignals(True)
+        self.region.setRegion([y0, y0 + height])
+        self.region.blockSignals(False)
+
+    def region_dragged(self):
+        """
+            Updates the row controls when the region overlay is dragged on the image.
+        """
+        lo, hi = self.region.getRegion()
+        y0 = max(int(round(lo)), 0)
+        height = max(int(round(hi - lo)), 1)
+        self.y0_spin.blockSignals(True)
+        self.height_spin.blockSignals(True)
+        self.y0_spin.setValue(y0)
+        self.height_spin.setValue(height)
+        self.y0_spin.blockSignals(False)
+        self.height_spin.blockSignals(False)

--- a/src/GUI/CameraDisplay.py
+++ b/src/GUI/CameraDisplay.py
@@ -41,6 +41,7 @@ class CameraDisplay(QtWidgets.QWidget):
         self.spectrometer = None
         self.last_frame = None
         self._auto_levels_pending = True
+        self._last_frame_shape = None
 
         # ---- image ----
         self.graphLayoutWidget = pg.GraphicsLayoutWidget()
@@ -77,6 +78,11 @@ class CameraDisplay(QtWidgets.QWidget):
         self.height_spin.setValue(1)
         self.auto_button = QtWidgets.QPushButton('Find signal band')
         self.apply_button = QtWidgets.QPushButton('Apply readout region')
+        self.fit_button = QtWidgets.QPushButton('Fit view')
+        self.fit_button.setToolTip(
+            'Reset zoom and colour levels to the last frame received.\n'
+            'Use this if the image looks empty: after switching between full frame and binned\n'
+            'mode the view can stay zoomed on rows that no longer exist in the new frame.')
         self.status_label = QtWidgets.QLabel('No frame received yet.')
         self.status_label.setWordWrap(True)
 
@@ -96,6 +102,7 @@ class CameraDisplay(QtWidgets.QWidget):
         region_layout.addWidget(self.height_spin)
         region_layout.addWidget(self.auto_button)
         region_layout.addWidget(self.apply_button)
+        region_layout.addWidget(self.fit_button)
         region_box.setLayout(region_layout)
         controls.addWidget(region_box, stretch=1)
 
@@ -113,6 +120,7 @@ class CameraDisplay(QtWidgets.QWidget):
         self.mode_full_frame.toggled.connect(self.mode_changed)
         self.auto_button.clicked.connect(self.find_signal_band)
         self.apply_button.clicked.connect(self.apply_roi)
+        self.fit_button.clicked.connect(self.fit_view)
         self.y0_spin.valueChanged.connect(self.spins_changed)
         self.height_spin.valueChanged.connect(self.spins_changed)
 
@@ -164,10 +172,19 @@ class CameraDisplay(QtWidgets.QWidget):
             return
         self.last_frame = frame
 
-        self.image.setImage(frame, autoLevels=self._auto_levels_pending)
-        if self._auto_levels_pending:
+        """ Re-fit the view whenever the frame shape changes (e.g. switching between full frame and
+        binned mode), not just on the very first frame. Otherwise the view can stay zoomed on rows a
+        smaller frame no longer has, making it look like nothing is being received. """
+        shape_changed = frame.shape != self._last_frame_shape
+        self._last_frame_shape = frame.shape
+        needs_reset = shape_changed or self._auto_levels_pending
+
+        self.image.setImage(frame, autoLevels=needs_reset)
+        if needs_reset:
             self.histogram.setLevels(*self.image.getLevels())
             self._auto_levels_pending = False
+        if shape_changed:
+            self.plot.getViewBox().autoRange()
 
         profile = frame.sum(axis=1)
         rows = np.arange(frame.shape[0])
@@ -182,6 +199,19 @@ class CameraDisplay(QtWidgets.QWidget):
             self.status_label.setText(
                 f'Frame {frame.shape[0]} rows x {frame.shape[1]} columns. '
                 f'Brightest row: {peak}. Max: {frame.max():.0f} counts.')
+
+    def fit_view(self):
+        """
+            Resets zoom and colour levels to the last frame received. Use this whenever the image
+            looks empty: it removes zoom and windowing as possible causes, leaving "no signal" as
+            the only remaining explanation.
+        """
+        if self.last_frame is None:
+            self.status_label.setText('No frame received yet: nothing to fit the view to.')
+            return
+        self.image.setImage(self.last_frame, autoLevels=True)
+        self.histogram.setLevels(*self.image.getLevels())
+        self.plot.getViewBox().autoRange()
 
     def find_signal_band(self, floor_fraction=0.1):
         """

--- a/src/GUI/main_GUI.ui
+++ b/src/GUI/main_GUI.ui
@@ -2716,6 +2716,11 @@ p, li { white-space: pre-wrap; }
              <string>2Q</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>LO scan</string>
+            </property>
+           </item>
           </widget>
           <widget class="QLabel" name="Measurement_TLO_delay_label">
            <property name="geometry">

--- a/src/compute/beams.py
+++ b/src/compute/beams.py
@@ -481,10 +481,6 @@ class Beam:
         elif TaylorPrefactorFlag == 'remove':
             coef = [c / f for c, f in zip(coef, TaylorFactor)]
 
-        # Add minus sign to the group delay (linear term)
-        if len(coef) > 1:
-            coef[1] *= -1
-
         return P(coef)
     
     @staticmethod

--- a/src/drivers/CryoDemo.py
+++ b/src/drivers/CryoDemo.py
@@ -3,11 +3,11 @@
 Created on Thu Sep  1 13:26:53 2022
 
 @author: NanoUltrafast2
-Hardware class to controll cryostat. All hardware classes require a definition of
-parameter_dict (set write and read parameter)
-parameter_display_dict (set Spinbox options)
-set_parameter function (assign set functions)
-
+Simulated cryostat driver used when no CryoPasqal hardware is available.
+Mirrors the parameter names (drivers.Optidry250.CryoPasqal.parameter_display_dict)
+and the command methods used by GUI.cryostattab.CryostatTab, so the dedicated
+cryostat page and the generic parameter tree behave the same way in demo mode
+as they do with real hardware.
 """
 
 import numpy as np
@@ -19,94 +19,203 @@ from collections import defaultdict
 class CryoDemo(QtCore.QThread):
 
     name = 'CryoDemo'
-    type = 'Cryostatas'
-    
+    type = 'Cryostat'
+
     def __init__(self):
         super(CryoDemo, self).__init__()
 
-
-        # set parameter dict
-        self.parameter_dict = defaultdict()
-        
-        # setting up variables, open array
-        self.set_T = []
-        self.current_T = []
-        self.stop = False
         self.parameter_display_dict = defaultdict(dict)
-        self.parameter_display_dict['set_T']['val'] = 5
-        self.parameter_display_dict['set_T']['unit'] = ' K'
-        self.parameter_display_dict['set_T']['max'] = 1000
-        self.parameter_display_dict['set_T']['read'] = False
-        self.parameter_display_dict['current_T']['val'] = 5
-        self.parameter_display_dict['current_T']['unit'] = ' K'
-        self.parameter_display_dict['current_T']['max'] = 1000
-        self.parameter_display_dict['current_T']['read'] = True
+
+        # --- Setpoint and Loop settings ---
+        self.parameter_display_dict['Set_T']['val'] = 5.0
+        self.parameter_display_dict['Set_T']['unit'] = ' K'
+        self.parameter_display_dict['Set_T']['min'] = 0
+        self.parameter_display_dict['Set_T']['max'] = 400
+        self.parameter_display_dict['Set_T']['read'] = False
+
+        self.parameter_display_dict['Regulation_Loop']['val'] = 1
+        self.parameter_display_dict['Regulation_Loop']['unit'] = ' loop'
+        self.parameter_display_dict['Regulation_Loop']['min'] = 1
+        self.parameter_display_dict['Regulation_Loop']['max'] = 2
+        self.parameter_display_dict['Regulation_Loop']['read'] = False
+
+        # --- Temperatures (Channels A to E) ---
+        for channel in ['ChannelA_T', 'ChannelB_T', 'ChannelC_T', 'ChannelD_T', 'ChannelE_T']:
+            self.parameter_display_dict[channel]['val'] = 5.0
+            self.parameter_display_dict[channel]['unit'] = ' K'
+            self.parameter_display_dict[channel]['min'] = 0
+            self.parameter_display_dict[channel]['max'] = 400
+            self.parameter_display_dict[channel]['read'] = True
+
+        # --- Pressures (Channels F and G) ---
+        self.parameter_display_dict['PressureF']['val'] = 101300.0
+        self.parameter_display_dict['PressureF']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureF']['min'] = 0
+        self.parameter_display_dict['PressureF']['max'] = 200000
+        self.parameter_display_dict['PressureF']['read'] = True
+
+        self.parameter_display_dict['PressureG']['val'] = 101300.0
+        self.parameter_display_dict['PressureG']['unit'] = ' Pa'
+        self.parameter_display_dict['PressureG']['min'] = 0
+        self.parameter_display_dict['PressureG']['max'] = 200000
+        self.parameter_display_dict['PressureG']['read'] = True
+
+        # --- PID Parameters ---
+        self.parameter_display_dict['Pid_P']['val'] = 0.0
+        self.parameter_display_dict['Pid_P']['unit'] = ' P'
+        self.parameter_display_dict['Pid_P']['min'] = 0
+        self.parameter_display_dict['Pid_P']['max'] = 1000
+        self.parameter_display_dict['Pid_P']['read'] = False
+
+        self.parameter_display_dict['Pid_I']['val'] = 0.0
+        self.parameter_display_dict['Pid_I']['unit'] = ' I'
+        self.parameter_display_dict['Pid_I']['min'] = 0
+        self.parameter_display_dict['Pid_I']['max'] = 1000
+        self.parameter_display_dict['Pid_I']['read'] = False
+
+        self.parameter_display_dict['Pid_D']['val'] = 0.0
+        self.parameter_display_dict['Pid_D']['unit'] = ' D'
+        self.parameter_display_dict['Pid_D']['min'] = 0
+        self.parameter_display_dict['Pid_D']['max'] = 1000
+        self.parameter_display_dict['Pid_D']['read'] = False
+
+        # --- Status and Compressor ---
+        self.parameter_display_dict['OnOff_comp']['val'] = 0
+        self.parameter_display_dict['OnOff_comp']['unit'] = ' state'
+        self.parameter_display_dict['OnOff_comp']['min'] = 0
+        self.parameter_display_dict['OnOff_comp']['max'] = 1
+        self.parameter_display_dict['OnOff_comp']['read'] = False
+
+        self.parameter_display_dict['Stability']['val'] = "In progress"
+        self.parameter_display_dict['Stability']['unit'] = ''
+        self.parameter_display_dict['Stability']['read'] = True
+
+        self.parameter_display_dict['Critical_State']['val'] = "OK"
+        self.parameter_display_dict['Critical_State']['unit'] = ''
+        self.parameter_display_dict['Critical_State']['read'] = True
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
         for key in self.parameter_display_dict.keys():
             self.parameter_dict[key] = self.parameter_display_dict[key]['val']
 
+        # --- History for stability calculation ---
+        self.temp_history = []
+        self.stability_threshold = 0.05
+        self.stability_window = 30
 
-        
-        # defining waitTime
-        self.waitTime = 0.1
-
-        # start updating temp
-        self.UpdateWorker = UpdateWorker()
-        self.UpdateWorker.new_T.connect(self.update_temp)
+        # start simulated background polling worker
+        self.UpdateWorker = DemoWorker(self.parameter_dict['ChannelA_T'], self.parameter_dict['Set_T'])
+        self.UpdateWorker.new_T.connect(self.update_all_data)
         self.UpdateWorker.start()
 
-    def set_parameter(self,parameter,value):
-        if parameter == 'set_T':
-            self.update_set_T(value)
+    def set_parameter(self, parameter, value):
+        """Called by the generic parameter tree (banderole) for writable params."""
+        self.parameter_dict[parameter] = value
+        if parameter in self.parameter_display_dict:
+            self.parameter_display_dict[parameter]['val'] = value
+
+        if parameter == 'Set_T':
             self.UpdateWorker.target = value
+        elif parameter == 'OnOff_comp':
+            self.set_compressor_state(bool(int(value)))
 
-    def update_set_T(self, set_temperature):
-        #set temperature to some degree K
-        #requests.put("http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature",json = {"platformTargetTemperature": set_temperature})
-        
-        print(f'Temperature set to {set_temperature}')
-              
-    def start_cool(self):
-        #start chamber cooldown
-        #requests.post('http://10.131.3.6:47101/v1/controller/methods/cooldown()')
-        
-        print("Cooldown has started")
-        
-    def start_warm(self):
-        # warmup the chamber
-        # requests.post('http://10.131.3.6:47101/v1/controller/methods/warmup()')
-        print("Warming Up")
-        
-    def update_temp(self, new_T):
-        self.parameter_dict['current_T'] = new_T
+    # --- Simulated hardware commands, mirror CryoPasqal's API used by CryostatTab ---
+
+    def set_temperature_setpoint(self, loop, target_temp):
+        self.parameter_dict['Set_T'] = target_temp
+        self.parameter_display_dict['Set_T']['val'] = target_temp
+        self.UpdateWorker.target = target_temp
+        print(f'[Demo] Loop {loop} setpoint updated to: {target_temp} K')
+
+    def set_heater_range(self, loop, range_level):
+        print(f'[Demo] Loop {loop} Heater Range updated to: {range_level}')
+
+    def set_pid_parameters(self, loop, p, i, d):
+        self.parameter_dict['Pid_P'] = p
+        self.parameter_dict['Pid_I'] = i
+        self.parameter_dict['Pid_D'] = d
+        print(f'[Demo] Loop {loop} PID parameters updated: P={p}, I={i}, D={d}')
+
+    def set_compressor_state(self, state_on):
+        self.parameter_dict['OnOff_comp'] = int(bool(state_on))
+        self.parameter_display_dict['OnOff_comp']['val'] = int(bool(state_on))
+        self.UpdateWorker.compressor_on = bool(state_on)
+        print(f"[Demo] Compressor set to: {'ON' if state_on else 'OFF'}")
+
+    def reset_compressor_alarm(self):
+        self.parameter_dict['Critical_State'] = 'OK'
+        self.parameter_display_dict['Critical_State']['val'] = 'OK'
+        print('[Demo] Alarm reset command sent.')
+
+    def update_all_data(self, data_list):
+        """Slot receiving simulated sensor data from the background worker."""
+        def assign_val(key, val):
+            self.parameter_dict[key] = val
+            self.parameter_display_dict[key]['val'] = val
+
+        assign_val('ChannelA_T', data_list[0])
+        assign_val('ChannelB_T', data_list[1])
+        assign_val('ChannelC_T', data_list[2])
+        assign_val('ChannelD_T', data_list[3])
+        assign_val('ChannelE_T', data_list[4])
+        assign_val('PressureF', data_list[5])
+        assign_val('PressureG', data_list[6])
+
+        self.calculate_stability(data_list[0])
+
+    def calculate_stability(self, current_temp):
+        self.temp_history.append(current_temp)
+        if len(self.temp_history) > self.stability_window:
+            self.temp_history.pop(0)
+
+        status = "In progress"
+        if len(self.temp_history) >= self.stability_window:
+            temp_range = max(self.temp_history) - min(self.temp_history)
+            if temp_range <= self.stability_threshold:
+                status = "Stable"
+
+        self.parameter_dict['Stability'] = status
+        self.parameter_display_dict['Stability']['val'] = status
 
 
+class DemoWorker(QtCore.QThread):
+    """Background worker that simulates the cryostat drifting toward its setpoint."""
 
-class UpdateWorker(QtCore.QThread):
+    new_T = QtCore.pyqtSignal(list)
 
-    new_T = QtCore.pyqtSignal(float)
-
-    def __init__(self):
-        super(UpdateWorker, self).__init__()
-        self.currentT = []
+    def __init__(self, initial_temp, initial_target):
+        super(DemoWorker, self).__init__()
         self.stop = False
-        self.waitTime = 0.1
-        self.target = 300
+        self.waitTime = 0.5
+        self.target = initial_target
+        self.current_T = initial_temp
+        self.compressor_on = False
+        self.cooling_rate = 0.5  # K per tick toward target when compressor is on
 
     def run(self):
         while not self.stop:
-            # calling the read temperature function
-            self.readtemp = self.read_T()
-
-            # waiting to remeasure the temperature
+            self.new_T.emit(self.simulate_step())
             time.sleep(self.waitTime)
-            self.new_T.emit(self.readtemp)
 
-    def read_T(self):
-        #read the current platform target temperature
-        #resp=requests.get('http://10.131.3.6:47101/v1/controller/properties/platformTargetTemperature')
-        target = self.target + np.random.rand(1)
-        return target
+    def simulate_step(self):
+        # Drift current_T toward target, faster when the compressor is on
+        rate = self.cooling_rate if self.compressor_on else self.cooling_rate * 0.1
+        delta = self.target - self.current_T
+        step = np.clip(delta, -rate, rate)
+        noise = (np.random.rand() - 0.5) * 0.05
+        self.current_T = self.current_T + step + noise
 
+        pressure_f = 101300.0 + (np.random.rand() - 0.5) * 50
+        pressure_g = 101300.0 + (np.random.rand() - 0.5) * 50
+
+        # Other channels loosely track the primary channel with small fixed offsets
+        return [
+            self.current_T,
+            self.current_T + 0.5,
+            self.current_T + 1.0,
+            self.current_T - 0.5,
+            self.current_T - 1.0,
+            pressure_f,
+            pressure_g,
+        ]

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -12,6 +12,7 @@ from drivers.Shamrock import Shamrock
 from drivers.Optidry250 import CryoPasqal
 from drivers.Pixis import Pixis
 from drivers.SpectraPro2300i import SpectraPro2300i
+from drivers.SpectraPro2300iDemo import SpectraPro2300iDemo
 
 logger = logging.getLogger(__name__)
 
@@ -87,12 +88,15 @@ def load_instruments():
         'Stresing': grating_params_stresing,
         'Pixis': grating_params_pixis
     }
-    Monochrom = SpectraPro2300i(grating_params) 
+    try:
+        Monochrom = SpectraPro2300i(grating_params)
+        logger.info('%s SpectraPro2300i connected' % datetime.datetime.now())
+    except Exception as e:
+        Monochrom = SpectraPro2300iDemo(grating_params)
+        logger.error('%s SpectraPro2300i initialization failed at interface startup. Error type %s' % (datetime.datetime.now(),str(e)))
+        logger.info('%s SpectraPro2300iDemo connected' % datetime.datetime.now())
 
-    
-    
-    devices['Monochrom'] = Monochrom 
-    logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
+    devices['Monochrom'] = Monochrom
 
     # initialize Cameras
     stresing_params={

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -59,27 +59,33 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
-    # Shamrock grating parameters
-    grating_params={
-        'focal_length_mm':163,
-        'delta':np.float64(-0.20488367116307532),
-        'gamma':np.float64(2.021864300924973),
-        'n0':np.float64(511.0), # Central pixel
-        'offset_adjust':0,
-        'd_grating':np.float64(6666.666666666667),
-        'x_pixel':26000.0,
-        'curvature':np.float64(3.1224154313329654e-06),
-    }
-    # SpectraPro 2300i grating parameters
-    grating_params = {
+    grating_params_stresing={
         'focal_length_mm':300,
-        'delta':np.float64(0),
-        'gamma':np.float64(0),
-        'n0':np.float64(511.0), # Central pixel
+        'f':np.float64(305381928.6149399),
+        'delta':np.float64(0.11432112488955509),
+        'gamma':np.float64(0.5337955112241486),
+        'n0':np.float64(539.4), # Central pixel
         'offset_adjust':0,
-        'd_grating':None,
-        'x_pixel':None,
-        'curvature':np.float64(0),
+        'd_grating':833.3333333333334,
+        'x_pixel':24000.0,
+        'curvature':np.float64(5.736575254871788e-07),
+    }
+    f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
+    grating_params_pixis = {
+        'focal_length_mm':300,
+        'f':np.float64(300000000.0),
+        'delta':np.float64(0.06),
+        'gamma':np.float64(0.5),
+        'n0':np.float64(516.6), # Central pixel
+        'offset_adjust':0,
+        'd_grating':833.3333333333334,
+        'x_pixel':26000,
+        'curvature':np.float64(0.0),
+    }
+
+    grating_params = {
+        'Stresing': grating_params_stresing,
+        'Pixis': grating_params_pixis
     }
     Monochrom = SpectraPro2300i(grating_params) 
 
@@ -92,7 +98,7 @@ def load_instruments():
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
-        'calibrated': False,
+        'calibrated': True,
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
@@ -100,7 +106,7 @@ def load_instruments():
     pixis_params = {
         'pixel_size_mm':26e-3,
         'num_pixels':1024,
-        'calibrated':False,
+        'calibrated':True,
         'calibrationThirdOrder':0,
         'calibrationSlope':0,
         'calibrationOffset':0

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -10,6 +10,8 @@ from drivers.SLMDemo import SLMDemo
 from drivers.Stresing import StresingCamera
 from drivers.Shamrock import Shamrock 
 from drivers.Optidry250 import CryoPasqal
+from drivers.Pixis import Pixis
+from drivers.SpectraPro2300i import SpectraPro2300i
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +59,9 @@ def load_instruments():
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
     # initialize MonochromDemo
+    # Shamrock grating parameters
     grating_params={
         'focal_length_mm':163,
-        'f':np.float64(330605663.74965495),
         'delta':np.float64(-0.20488367116307532),
         'gamma':np.float64(2.021864300924973),
         'n0':np.float64(511.0), # Central pixel
@@ -68,11 +70,25 @@ def load_instruments():
         'x_pixel':26000.0,
         'curvature':np.float64(3.1224154313329654e-06),
     }
-    Monochrom = Shamrock(grating_params) 
+    # SpectraPro 2300i grating parameters
+    grating_params = {
+        'focal_length_mm':300,
+        'delta':np.float64(0),
+        'gamma':np.float64(0),
+        'n0':np.float64(511.0), # Central pixel
+        'offset_adjust':0,
+        'd_grating':None,
+        'x_pixel':None,
+        'curvature':np.float64(0),
+    }
+    Monochrom = SpectraPro2300i(grating_params) 
+
+    
+    
     devices['Monochrom'] = Monochrom 
     logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
 
-    # initialize StresingDemo
+    # initialize Cameras
     stresing_params={
         'pixel_size_mm':24e-3,
         'num_pixels':1010,
@@ -80,6 +96,14 @@ def load_instruments():
         'calibrationThirdOrder': -3e-5,
         'calibrationSlope': 0.9891,
         'calibrationOffset': -51.163
+    }
+    pixis_params = {
+        'pixel_size_mm':26e-3,
+        'num_pixels':1024,
+        'calibrated':False,
+        'calibrationThirdOrder':0,
+        'calibrationSlope':0,
+        'calibrationOffset':0
     }
 
     spectrometers = {}
@@ -91,6 +115,14 @@ def load_instruments():
         logger.info('%s Stresing connected' % datetime.datetime.now())
     except Exception as e:
         logger.warning(f'Stresing failed: {e}')
+
+    try:
+        camera = Pixis(pixis_params)
+        spectrometers['Pixis'] = camera
+        camera.attach_to_monochromator(Monochrom)
+        logger.info('%s Pixis connected' % datetime.datetime.now())
+    except Exception as e:
+        logger.warning(f'Pixis failed: {e}')
 
     try:
         from drivers.OceanSpectrometer import OceanSpectrometer

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -64,7 +64,7 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['unit'] = ' celsius'
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
-        self.parameter_display_dict['sensor_T']['read'] = True
+        self.parameter_display_dict['sensor_T']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -223,8 +223,9 @@ class Pixis(QtCore.QThread):
         spectrum = spectrum[0, :]
         return spectrum
 
-    def update_temperature(self,temperature):
+    def update_temperature(self, temperature):
         self.parameter_dict['sensor_T'] = temperature
+        self.parameter_display_dict['sensor_T']['val'] = temperature
 
 
 class CameraWorker(QtCore.QThread):

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -119,7 +119,8 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array()
+        self.calculate_wavelength_array()
+        return self.wavelengths
 
     def calculate_wavelength_array(self):
         """
@@ -136,32 +137,32 @@ class Pixis(QtCore.QThread):
             focal_length_mm = self.hardware_params['focal_length_mm']
             num_pixels = self.hardware_params['num_pixels']
         
-        calibrated = False
-        if calibrated:
-            pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 300  # specs of SP2150
-            num_pixels = 1024  # specs of PIXIS
+        if self.hardware_params['calibrated']:
 
-            #
+            pixel_size_mm = 26 / 1E3  # specs of PIXIS
+            focal_length_mm = 300  # specs of SP2300
+            num_pixels = 1024  # specs of PIXIS
 
             wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
             # calibration from notebook
-            f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
-
-
+            f=self.hardware_params['f']
+            delta=self.hardware_params['delta']
+            gamma=self.hardware_params['gamma']
+            n0=self.hardware_params['n0']
+            offset_adjust=self.hardware_params['offset_adjust']
+            d_grating=self.hardware_params['d_grating']
+            x_pixel=self.hardware_params['x_pixel']
+            curvature=self.hardware_params['curvature']
 
             n = px - (n0 + offset_adjust * wl_center)
-
-            # print('psi top', m_order* wl_center)
-            # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
 
             psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
             eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
-            wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+            self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
             focal_length_mm = 300  # specs of SP2150
@@ -177,9 +178,7 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-
-        return wavelengths
+            self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
     def attach_to_monochromator(self,monochromator):
         """
@@ -189,7 +188,7 @@ class Pixis(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Pixis'))
     
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -77,9 +77,27 @@ class Pixis(QtCore.QThread):
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
 
-        # set the ROI so the camera is acting like a 1D array of 1024 pixels
-        roi = {"x": 0, "width": 1024, "x_binning": 1, "y": 0, "height": 1, "y_binning": 1}
-        self.camera.set_attribute_value("ROIs", [roi])
+        # Determine the number of sensor rows available for vertical binning.
+        # The PIXIS used here is 1024 x 256, but ask the camera rather than assume.
+        self.sensor_height = int(self.hardware_params.get('sensor_height', 256))
+        try:
+            detector_size = self.camera.get_detector_size()  # (width, height)
+            if detector_size is not None and len(detector_size) == 2:
+                self.sensor_height = int(detector_size[1])
+        except Exception as e:
+            print(f'Pixis: could not query detector size, assuming {self.sensor_height} rows. {e}')
+
+        """ Vertical readout configuration.
+        The sensor is 2D: the horizontal axis is wavelength, the vertical axis is position along the
+        spectrograph entrance slit. Reading a single row therefore only samples one height in the slit
+        and discards the signal collected on every other row.
+        set_binned_roi() sums rows ON CHIP (charge is summed before the readout amplifier), so the read
+        noise is paid once instead of once per row. That is what makes weak signals usable.
+        Defaults come from hardware_params so each setup can record its own alignment. """
+        self.roi_y0 = int(self.hardware_params.get('roi_y0', 0))
+        self.roi_height = int(self.hardware_params.get('roi_height', self.sensor_height))
+        self.roi_binning = int(self.hardware_params.get('roi_binning', self.roi_height))
+        self.set_roi(self.roi_y0, self.roi_height, self.roi_binning, restart=False)
 
         # initialize camera
         self.worker = CameraWorker(self.camera,self.int_time)
@@ -190,6 +208,65 @@ class Pixis(QtCore.QThread):
         self.type='Spectrometer'
         self.hardware_params.update(self.monochromator.get_hardware_parameters('Pixis'))
     
+    def set_roi(self, y0, height, binning=None, restart=True):
+        """
+            Sets the vertical region of the sensor that is read out, and how many of its rows are
+            summed on chip.
+            input:
+                - y0 (int): index of the first sensor row to read
+                - height (int): number of sensor rows covered by the region
+                - binning (int, default None): number of rows summed on chip. None means sum the whole
+                  region into a single row (the high signal-to-noise mode used for measurements).
+                  Pass 1 to keep every row separate (the 2D mode used for alignment).
+                - restart (bool, default True): restart continuous acquisition if it was running
+            output:
+                - dict: the region of interest actually applied
+        """
+        y0 = int(np.clip(y0, 0, max(self.sensor_height - 1, 0)))
+        height = int(np.clip(height, 1, self.sensor_height - y0))
+        binning = height if binning is None else int(np.clip(binning, 1, height))
+        # PICam requires the region height to be an exact multiple of the binning factor
+        height = max((height // binning) * binning, binning)
+
+        was_acquiring = getattr(self, 'worker', None) is not None and self.worker.acquiring
+        if was_acquiring:
+            self.stop_acquisition()
+
+        roi = {"x": 0, "width": 1024, "x_binning": 1,
+               "y": y0, "height": height, "y_binning": binning}
+        self.camera.set_attribute_value("ROIs", [roi])
+        self.roi_y0, self.roi_height, self.roi_binning = y0, height, binning
+        print(f'Pixis ROI: rows {y0}-{y0 + height - 1} of {self.sensor_height}, '
+              f'binning {binning} -> {height // binning} row(s) read out')
+
+        if was_acquiring and restart:
+            self.start_acquisition()
+        return roi
+
+    def set_binned_roi(self, y0, height):
+        """
+            Measurement mode: sum `height` sensor rows starting at `y0` into a single row on chip.
+            input:
+                - y0 (int): index of the first sensor row of the signal
+                - height (int): number of rows the signal spans
+        """
+        return self.set_roi(y0, height, binning=height)
+
+    def set_full_frame(self):
+        """
+            Alignment mode: read every sensor row separately, giving the full 2D image.
+            Slower and noisier per row, but shows where the signal actually sits on the slit.
+        """
+        return self.set_roi(0, self.sensor_height, binning=1)
+
+    def get_roi(self):
+        """
+            Returns the currently applied vertical readout configuration.
+            output:
+                - tuple (y0, height, binning)
+        """
+        return self.roi_y0, self.roi_height, self.roi_binning
+
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """
         self.camera.start_acquisition()
@@ -220,7 +297,13 @@ class Pixis(QtCore.QThread):
                 self.new_spectrum = False
             spectrum = spectrum / self.avg_scan
         self.stop_acquisition()
-        spectrum = spectrum[0, :]
+        """ The camera returns one row per binning group: a single row in binned (measurement) mode,
+        every sensor row in full frame (alignment) mode. Any remaining rows are summed here so both
+        modes hand back a 1D spectrum. Counts therefore scale with the number of rows summed, which
+        matters when comparing a spectrum to a background taken with a different region. """
+        spectrum = np.asarray(spectrum)
+        if spectrum.ndim > 1:
+            spectrum = spectrum.sum(axis=0)
         return spectrum
 
     def update_temperature(self, temperature):

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -22,21 +22,21 @@ from PyQt5 import QtCore
 from collections import defaultdict
 from pylablib.devices import PrincetonInstruments
 import time
-import serial
 import re
 
 class Pixis(QtCore.QThread):
 
     name = 'Pixis'
     
-    def __init__(self):
+    def __init__(self, hardware_params):
         super(Pixis, self).__init__()
 
         #self.camera.start()
-        self.wavelength =  np.linspace(200,1000,1024) # get property from Worker
+        self.wavelength = np.linspace(200,1000,1024) # get property from Worker
         self.px0 = np.linspace(1,1024,1024)
-        self.spec_length = (252,1024) # get property from Worker
+        self.spec_length = 1024 #(252,1024) # get property from Worker
         self.image = np.zeros(self.spec_length)
+        self.hardware_params = hardware_params
 
         # Indicate shutter, required to discriminate between different detectors
         self.shutter = True
@@ -46,30 +46,6 @@ class Pixis(QtCore.QThread):
         self.int_time = 100
         self.binned_spec = np.zeros(self.spec_length)
         self.new_spectrum = False
-
-        # set up spectrograph
-        self.serial_busy = False
-        port = 'COM6'
-        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
-                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
-        # get startup values
-        self.grating = float(self.write_command('?GRATING')[0])
-        numbers = self.write_command('?GRATINGS')
-        self.num_gratings = int((len(numbers)-8)/2)
-        self.grating_densities = np.zeros(self.num_gratings)
-        self.grating_blazes = np.zeros(self.num_gratings)
-        for i in range(self.num_gratings):
-            self.grating_densities[i] = numbers[i*3 + 1]
-            self.grating_blazes[i] = numbers[i * 3 + 2]
-        self.center_wl = float(self.write_command('?NM')[0])
-        print(self.center_wl)
-        print(self.grating_densities)
-        print(self.grating_blazes)
-        print(self.grating)
-        print('SP2150 grating info: ', numbers)
-        print('SP2150 grating densities: ',self.grating_densities)
-        print('SP2150 grating blazes: ',self.grating_blazes)
-        print('SP2150 selected grating: ',self.grating)
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -89,14 +65,6 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
         self.parameter_display_dict['sensor_T']['read'] = True
-        self.parameter_display_dict['center_wl']['val'] = self.center_wl
-        self.parameter_display_dict['center_wl']['unit'] = ' nm'
-        self.parameter_display_dict['center_wl']['max'] = 2000
-        self.parameter_display_dict['center_wl']['read'] = False
-        self.parameter_display_dict['grating']['val'] = self.grating
-        self.parameter_display_dict['grating']['unit'] = ' grat'
-        self.parameter_display_dict['grating']['max'] = 3
-        self.parameter_display_dict['grating']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -108,6 +76,10 @@ class Pixis(QtCore.QThread):
         print(PrincetonInstruments.list_cameras())
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
+
+        # set the ROI so the camera is acting like a 1D array of 1024 pixels
+        roi = {"x": 0, "width": 1024, "x_binning": 1, "y": 0, "height": 1, "y_binning": 1}
+        self.camera.set_attribute_value("ROIs", [roi])
 
         # initialize camera
         self.worker = CameraWorker(self.camera,self.int_time)
@@ -134,16 +106,6 @@ class Pixis(QtCore.QThread):
         elif parameter == 'avg_scan':
             self.parameter_dict['avg_scan'] = value
             self.avg_scan = int(value)
-        elif parameter == 'center_wl':
-            cmd = f'{value:0.3f} GOTO'
-            self.write_command(cmd)
-            self.parameter_dict['center_wl'] = value
-            self.center_wl = value
-        elif parameter == 'grating':
-            cmd = f'{value:1.0f} GRATING'
-            self.write_command(cmd)
-            self.parameter_dict['grating'] = value
-            self.grating = value
 
 
     def update_spectrum(self, spec, int_time):
@@ -157,28 +119,32 @@ class Pixis(QtCore.QThread):
     def get_wavelength(self):
         """This simply returns the wavelength. In Colbert this needs to be adapted if the calibration
          changes. This function will be accessible from MeasurementClasses. """
-        return self.calculate_wavelength_array(self.center_wl,self.grating_densities[int(self.grating-1)])
+        return self.calculate_wavelength_array()
 
-    def calculate_wavelength_array(self,center_wavelength_nm,grating_lines_per_mm):
+    def calculate_wavelength_array(self):
         """
         Calculate the wavelength array for a PIXIS camera on SP-2150 spectrograph.
 
         Parameters:
-            center_wavelength_nm: Central wavelength (nm)
-            grating_lines_per_mm: Groove density (lines/mm)
 
         Returns:
             wavelengths: 1D numpy array of wavelengths (nm)
         """
-        calibrated = True
+        if self.monochromator is not None:
+            self.center_wavelength,self.grating_lines_per_mm=self.monochromator.get_monochromator_parameters()
+            pixel_size_mm =self.hardware_params['pixel_size_mm'] 
+            focal_length_mm = self.hardware_params['focal_length_mm']
+            num_pixels = self.hardware_params['num_pixels']
+        
+        calibrated = False
         if calibrated:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             #
 
-            wl_center = center_wavelength_nm
+            wl_center = self.center_wavelength
             m_order = 1
             px = self.px0
 
@@ -198,11 +164,11 @@ class Pixis(QtCore.QThread):
             wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
         else:
             pixel_size_mm = 26 / 1E3  # specs of PIXIS
-            focal_length_mm = 150  # specs of SP2150
+            focal_length_mm = 300  # specs of SP2150
             num_pixels = 1024  # specs of PIXIS
 
             # Calculate linear dispersion (nm/mm)
-            dispersion = 1e6 / (focal_length_mm * grating_lines_per_mm)
+            dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
             # Center pixel
             center_pixel = num_pixels // 2
@@ -211,10 +177,20 @@ class Pixis(QtCore.QThread):
             pixel_indices = np.arange(num_pixels)
 
             # Wavelength at each pixel
-            wavelengths = center_wavelength_nm + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
+            wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
 
         return wavelengths
 
+    def attach_to_monochromator(self,monochromator):
+        """
+            Attaches the camera to a monochromator, letting the camera interface know where to get the monochromator parameters from.
+            input:
+                - monochromator (Monochromator QThread): The interface to the monochromator
+        """
+        self.monochromator=monochromator
+        self.type='Spectrometer'
+        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+    
     def start_acquisition(self):
         """ Sets camera to continuous acquisition mode. """
         self.camera.start_acquisition()
@@ -229,6 +205,7 @@ class Pixis(QtCore.QThread):
         """ Gets the intensity. The example include the possibility of averaging several spectra and to
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
+        self.start_acquisition()
         if self.avg_scan == 1:
             while not self.new_spectrum:
                 time.sleep(0.01)
@@ -243,35 +220,12 @@ class Pixis(QtCore.QThread):
                 spectrum = spectrum + self.spectrum
                 self.new_spectrum = False
             spectrum = spectrum / self.avg_scan
+        self.stop_acquisition()
+        spectrum = spectrum[0, :]
         return spectrum
 
     def update_temperature(self,temperature):
         self.parameter_dict['sensor_T'] = temperature
-
-    def write_command(self, cmd):
-        """ Command to write to serial handles timeout by blocking serial commands
-        Args:
-            ser: serial object
-            cmd: write command as defined in PI API
-
-        Returns: read string with only digit content. For troubleshooting, consider printing
-        the entire answer string
-        """
-        cmd_bytes = cmd.encode('ASCII')
-        self.ser.write(cmd_bytes + b"\r")
-        out = bytearray()
-        char = b""
-        missed_char_count = 0
-        while char != b"k":
-            char = self.ser.read()
-            if char == b"":  # handles a timeout here
-                missed_char_count += 1
-                self.serial_busy = True
-                time.sleep(0.1)
-            out += char
-        self.serial_busy = False
-        return re.findall(r'\d+', out.decode().strip())
-
 
 
 class CameraWorker(QtCore.QThread):
@@ -288,7 +242,7 @@ class CameraWorker(QtCore.QThread):
 
         # definition of some parameters
         self.camera = camera
-        self.spec_length = (252,1024)
+        self.spec_length = 1024
         self.change_int_time = False
         self.spectrum = np.zeros(self.spec_length)
         self.int_time = int_time

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -110,7 +110,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
 
-    def get_hardware_parameters(self):
+    def get_hardware_parameters(self, name):
         """
             Returns the hardware parameters of the monochromator
             output:
@@ -125,7 +125,8 @@ class SpectraPro2300i(QtCore.QThread):
                     - curvature
 
         """
-        return self.hardware_params
+        return self.hardware_params[name]
+    
     def get_monochromator_parameters(self):
         """
             Returns the current parameters of the monochromator.
@@ -133,6 +134,4 @@ class SpectraPro2300i(QtCore.QThread):
                 - central_wavelength (np.float): the central wavelength in nm
                 - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
         """
-        return self.center_wl, self.grating_densities[int(self.grating)]
-
-
+        return self.center_wl, self.grating_densities[int(self.grating-1)]

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -1,0 +1,138 @@
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: KatieKoch, Felix Thouin
+"""
+
+import numpy as np
+from PyQt5 import QtCore
+from collections import defaultdict
+import time
+import serial
+import re
+
+class SpectraPro2300i(QtCore.QThread):
+    
+    name = 'SpectraPro2300i'
+    type = 'Monochromator'
+    
+    def __init__(self,hardware_params):
+        super(SpectraPro2300i, self).__init__()
+
+        # set up spectrograph
+        self.serial_busy = False
+        port = 'COM5'
+        self.ser = serial.Serial(port=port, baudrate=9600, bytesize=8, parity='N',
+                                 stopbits=1, xonxoff=0, rtscts=0, timeout=0.02)
+        # get startup values
+        self.grating = float(self.write_command('?GRATING')[0])
+        numbers = self.write_command('?GRATINGS')
+        self.num_gratings = int((len(numbers)-8)/2)
+        self.grating_densities = np.zeros(self.num_gratings)
+        self.grating_blazes = np.zeros(self.num_gratings)
+        for i in range(self.num_gratings):
+            self.grating_densities[i] = numbers[i*3 + 1]
+            self.grating_blazes[i] = numbers[i * 3 + 2]
+        self.center_wl = float(self.write_command('?NM')[0])
+        print(self.center_wl)
+        print(self.grating_densities)
+        print(self.grating_blazes)
+        print(self.grating)
+        print('SP2300 grating info: ', numbers)
+        print('SP2300 grating densities: ',self.grating_densities)
+        print('SP2300 grating blazes: ',self.grating_blazes)
+        print('SP2300 selected grating: ',self.grating)
+
+        # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
+        self.hardware_params=hardware_params
+        # set parameter dict
+        self.parameter_dict = defaultdict()
+        """ Set up the parameter dict. 
+        Here, all properties of parameters to be handled by the parameter dict are defined."""
+        
+        self.parameter_display_dict = defaultdict(dict)
+        
+        self.parameter_dict['central_wave'] = self.center_wl
+        self.parameter_dict['grating'] = self.grating
+        
+        self.parameter_display_dict['central_wave']['val'] = self.center_wl
+        self.parameter_display_dict['central_wave']['unit'] = ' nm'
+        self.parameter_display_dict['central_wave']['min'] = 200.00
+        self.parameter_display_dict['central_wave']['max'] = 1100.00
+        self.parameter_display_dict['central_wave']['read'] = False
+        
+        self.parameter_display_dict['grating']['val'] = self.grating
+        self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['grating']['max'] = 3
+        self.parameter_display_dict['grating']['read'] = False
+
+        # set up parameter dict that only contains value. (faster to access)
+        self.parameter_dict = {}
+        for key in self.parameter_display_dict.keys():
+            self.parameter_dict[key] = self.parameter_display_dict[key]['val']
+    
+    def write_command(self, cmd):
+        """ Command to write to serial handles timeout by blocking serial commands
+        Args:
+            ser: serial object
+            cmd: write command as defined in PI API
+
+        Returns: read string with only digit content. For troubleshooting, consider printing
+        the entire answer string
+        """
+        cmd_bytes = cmd.encode('ASCII')
+        self.ser.write(cmd_bytes + b"\r")
+        out = bytearray()
+        char = b""
+        missed_char_count = 0
+        while char != b"k":
+            char = self.ser.read()
+            if char == b"":  # handles a timeout here
+                missed_char_count += 1
+                self.serial_busy = True
+                time.sleep(0.1)
+            out += char
+        self.serial_busy = False
+        return re.findall(r'\d+', out.decode().strip())
+   
+    def set_parameter(self, parameter, value):
+        """REQUIRED. This function defines how changes in the parameter tree are handled.
+        In devices with workers, a pause of continuous acquisition might be required. """
+        if parameter == 'central_wave':
+            cmd = f'{value:0.3f} GOTO'
+            self.write_command(cmd)
+            self.parameter_dict['center_wave'] = value
+            self.center_wl = value
+        elif parameter == 'grating':
+            cmd = f'{value:1.0f} GRATING'
+            self.write_command(cmd)
+            self.parameter_dict['grating'] = value
+            self.grating = value
+
+    def get_hardware_parameters(self):
+        """
+            Returns the hardware parameters of the monochromator
+            output:
+                - hardware_parameters (dict): A dictionnary of all hardware parameters including:
+                    - f
+                    - delta
+                    - gamma
+                    - n0
+                    - offset_adjust
+                    - d_grating
+                    - x_pixel
+                    - curvature
+
+        """
+        return self.hardware_params
+    def get_monochromator_parameters(self):
+        """
+            Returns the current parameters of the monochromator.
+            output:
+                - central_wavelength (np.float): the central wavelength in nm
+                - grating_lines_per_mm (np.float): the number of groove per mm of the selected grating
+        """
+        return self.center_wl, self.grating_densities[int(self.grating)]
+
+

--- a/src/drivers/SpectraPro2300i.py
+++ b/src/drivers/SpectraPro2300i.py
@@ -35,6 +35,7 @@ class SpectraPro2300i(QtCore.QThread):
             self.grating_densities[i] = numbers[i*3 + 1]
             self.grating_blazes[i] = numbers[i * 3 + 2]
         self.center_wl = float(self.write_command('?NM')[0])
+        self.mirror = float(self.write_command('?MIR')[0])
         print(self.center_wl)
         print(self.grating_densities)
         print(self.grating_blazes)
@@ -55,6 +56,7 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_dict['central_wave'] = self.center_wl
         self.parameter_dict['grating'] = self.grating
+        self.parameter_dict['mirror'] = self.mirror
         
         self.parameter_display_dict['central_wave']['val'] = self.center_wl
         self.parameter_display_dict['central_wave']['unit'] = ' nm'
@@ -64,8 +66,15 @@ class SpectraPro2300i(QtCore.QThread):
         
         self.parameter_display_dict['grating']['val'] = self.grating
         self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['mirror']['min'] = 1
         self.parameter_display_dict['grating']['max'] = 3
         self.parameter_display_dict['grating']['read'] = False
+
+        self.parameter_display_dict['mirror']['val'] = self.mirror
+        self.parameter_display_dict['mirror']['unit'] = ' mirror'
+        self.parameter_display_dict['mirror']['min'] = 0
+        self.parameter_display_dict['mirror']['max'] = 1
+        self.parameter_display_dict['mirror']['read'] = False
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
@@ -109,6 +118,11 @@ class SpectraPro2300i(QtCore.QThread):
             self.write_command(cmd)
             self.parameter_dict['grating'] = value
             self.grating = value
+        elif parameter == 'mirror':
+            cmd = f'{value:1.0f} MIRROR'
+            self.write_command(cmd)
+            self.parameter_dict['mirror'] = value
+            self.mirror = value
 
     def get_hardware_parameters(self, name):
         """

--- a/src/drivers/SpectraPro2300iDemo.py
+++ b/src/drivers/SpectraPro2300iDemo.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+Demo fallback for drivers.SpectraPro2300i.SpectraPro2300i.
+
+Used when no SP2300i is connected (wrong/missing COM port). Implements the same interface the
+attached cameras rely on (get_monochromator_parameters, get_hardware_parameters, set_parameter,
+parameter_display_dict/parameter_dict) so Pixis and Stresing behave the same way whether the real
+monochromator is present or not.
+
+MonochromDemo.py and MonochromatorDemo.py predate this driver and don't implement that interface,
+which is why load_instruments() could not fall back to them.
+"""
+
+import numpy as np
+from PyQt5 import QtCore
+from collections import defaultdict
+
+
+class SpectraPro2300iDemo(QtCore.QThread):
+
+    name = 'SpectraPro2300iDemo'
+    type = 'Monochromator'
+
+    def __init__(self, hardware_params):
+        super(SpectraPro2300iDemo, self).__init__()
+
+        self.hardware_params = hardware_params
+
+        self.center_wl = 800.0
+        self.grating = 1
+        self.mirror = 0
+        self.num_gratings = 3
+        self.grating_densities = np.array([1200.0, 600.0, 300.0])
+        self.grating_blazes = np.array([500.0, 750.0, 1000.0])
+
+        self.parameter_display_dict = defaultdict(dict)
+
+        self.parameter_display_dict['central_wave']['val'] = self.center_wl
+        self.parameter_display_dict['central_wave']['unit'] = ' nm'
+        self.parameter_display_dict['central_wave']['min'] = 200.00
+        self.parameter_display_dict['central_wave']['max'] = 1100.00
+        self.parameter_display_dict['central_wave']['read'] = False
+
+        self.parameter_display_dict['grating']['val'] = self.grating
+        self.parameter_display_dict['grating']['unit'] = ' grat'
+        self.parameter_display_dict['grating']['min'] = 1
+        self.parameter_display_dict['grating']['max'] = self.num_gratings
+        self.parameter_display_dict['grating']['read'] = False
+
+        self.parameter_display_dict['mirror']['val'] = self.mirror
+        self.parameter_display_dict['mirror']['unit'] = ' mirror'
+        self.parameter_display_dict['mirror']['min'] = 0
+        self.parameter_display_dict['mirror']['max'] = 1
+        self.parameter_display_dict['mirror']['read'] = False
+
+        self.parameter_dict = {}
+        for key in self.parameter_display_dict.keys():
+            self.parameter_dict[key] = self.parameter_display_dict[key]['val']
+
+    def set_parameter(self, parameter, value):
+        """REQUIRED. This function defines how changes in the parameter tree are handled."""
+        if parameter == 'central_wave':
+            self.parameter_dict['central_wave'] = value
+            self.center_wl = value
+        elif parameter == 'grating':
+            self.parameter_dict['grating'] = value
+            self.grating = value
+        elif parameter == 'mirror':
+            self.parameter_dict['mirror'] = value
+            self.mirror = value
+
+    def get_hardware_parameters(self, name):
+        """
+            Returns the hardware calibration parameters for the given camera.
+            input:
+                - name (str): camera name, e.g. 'Pixis' or 'Stresing'
+            output:
+                - hardware_parameters (dict)
+        """
+        return self.hardware_params[name]
+
+    def get_monochromator_parameters(self):
+        """
+            Returns the current parameters of the monochromator.
+            output:
+                - central_wavelength (float): the central wavelength in nm
+                - grating_lines_per_mm (float): the number of grooves per mm of the selected grating
+        """
+        return self.center_wl, self.grating_densities[int(self.grating - 1)]

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -264,9 +264,13 @@ class StresingCamera(QtCore.QThread):
 
             if self.hardware_params['calibrated']:
 
+                pixel_size_mm = 24 / 1E3  # specs of Sresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of stresing
+
                 wl_center = self.center_wavelength
                 m_order = 1
-                px = np.linspace(1,1024,1024)
+                px = np.linspace(1,1010,1010)
 
                 # calibration from notebook
                 f=self.hardware_params['f']
@@ -280,14 +284,17 @@ class StresingCamera(QtCore.QThread):
 
                 n = px - (n0 + offset_adjust * wl_center)
 
-                # print('psi top', m_order* wl_center)
-                # print('psi bottom', (2*d_grating*np.cos(gamma/2)) )
-
                 psi = np.arcsin(m_order * wl_center / (2 * d_grating * np.cos(gamma / 2)))
                 eta = np.arctan(n * x_pixel * np.cos(delta) / (f + n * x_pixel * np.sin(delta)))
 
                 self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
+
             else:
+
+                pixel_size_mm = 24 / 1E3  # specs of Stresing
+                focal_length_mm = 300  # specs of SP2300i
+                num_pixels = 1010  # specs of Stresing
+
                 # Calculate linear dispersion (nm/mm)
                 dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
 
@@ -299,8 +306,7 @@ class StresingCamera(QtCore.QThread):
 
                 # Wavelength at each pixel
                 self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-                # Refine the calibration using a mercury spectral lamp
-                self.wavelengths = self.hardware_params['calibrationThirdOrder']*self.wavelengths**2 + self.hardware_params['calibrationSlope']*self.wavelengths + self.hardware_params['calibrationOffset']
+
         else:
             self.wavelengths= self.hardware_params['num_pixels']
             logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength'%datetime.datetime.now())
@@ -313,7 +319,7 @@ class StresingCamera(QtCore.QThread):
         """
         self.monochromator=monochromator
         self.type='Spectrometer'
-        self.hardware_params.update(self.monochromator.get_hardware_parameters())
+        self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
@@ -332,6 +338,7 @@ class StresingCamera(QtCore.QThread):
             time.sleep(0.01)
             self.new_spectrum = False
         self.spec = np.array(self.spectrum[13:-1])
+        self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
         return self.spec
 

--- a/src/main.py
+++ b/src/main.py
@@ -424,8 +424,11 @@ class MainInterface(QtWidgets.QMainWindow):
             Points the Camera tab at the active spectrometer.
             Cameras with a 2D sensor expose their raw frames through a worker signal; those frames are
             routed straight to the view so alignment can be checked without going through DataHandling,
-            which only carries the 1D spectra used for measurements. Spectrometers without such a
-            worker simply leave the tab disabled.
+            which only carries the 1D spectra used for measurements. Spectrometers without a
+            configurable readout region (checked via set_binned_roi, the same test CameraDisplay
+            uses to enable its controls) simply leave the tab disabled: their worker's sendSpectrum
+            signal is not guaranteed to share Pixis's (image, int_time) signature, and CameraDisplay
+            is only meaningful for a 2D sensor in the first place.
         '''
         previous = getattr(self, '_camera_display_source', None)
         if previous is not None:
@@ -439,7 +442,7 @@ class MainInterface(QtWidgets.QMainWindow):
         self.CameraDisplay.set_spectrometer(spectrometer)
 
         worker = getattr(spectrometer, 'worker', None)
-        if worker is not None and hasattr(worker, 'sendSpectrum'):
+        if worker is not None and hasattr(spectrometer, 'set_binned_roi') and hasattr(worker, 'sendSpectrum'):
             worker.sendSpectrum.connect(self.CameraDisplay.set_data)
             self._camera_display_source = worker
             logger.info('%s Camera view connected to %s'

--- a/src/main.py
+++ b/src/main.py
@@ -267,29 +267,7 @@ class MainInterface(QtWidgets.QMainWindow):
             item = QtWidgets.QTreeWidgetItem([device.capitalize()])
             self.parameter_tree.addTopLevelItem(item)
             for param in self.parameter_dic[device].keys():
-                child =QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
-                name_widget = QtWidgets.QLabel(param)
-                self.parameter_widgets[param] = QtWidgets.QDoubleSpinBox()
-                #self.parameter_widgets[param].setFixedSize(self.parameter_widgets[param].__sizeof__(), 16)
-                self.parameter_widgets[param].setReadOnly(self.parameter_dic[device][param]['read'])
-                try:
-                    self.parameter_widgets[param].setSuffix(self.parameter_dic[device][param]['unit'])
-                    self.parameter_widgets[param].setMaximum(self.parameter_dic[device][param]['max'])
-                except:
-                    pass
-                try:
-                    self.parameter_widgets[param].setMinimum(self.parameter_dic[device][param]['min'])
-                except:
-                    pass
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    self.parameter_widgets[param].setValue(self.parameter_dic[device][param]['val'])
-                    self.parameter_widgets[param].editingFinished.connect(partial(self.set_parameter,param))
-                    self.writeonly_parameter.append(param)
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, self.parameter_widgets[param])
+                self._build_parameter_tree_item(item, device, param)
 
         # start DataHandling
         # self.spec_length = self.devices['spectrometer'].get_num_pixel()
@@ -440,39 +418,53 @@ class MainInterface(QtWidgets.QMainWindow):
             self.parameter_tree.addTopLevelItem(item)
 
             for param in self.parameter_dic[device].keys():
-                child = QtWidgets.QTreeWidgetItem()
-                item.addChild(child)
+                self._build_parameter_tree_item(item, device, param)
 
-                name_widget = QtWidgets.QLabel(param)
-                spin = QtWidgets.QDoubleSpinBox()
-                self.parameter_widgets[param] = spin
+    def _build_parameter_tree_item(self, item, device, param):
+        '''
+            Builds one row of the parameter tree (name label + value spinbox) for a
+            single device parameter and registers the resulting widget in
+            self.parameter_widgets/readonly_parameter/writeonly_parameter.
+            Cryostat parameters are always shown read-only here regardless of the
+            driver's 'read' flag: control of the cryostat must go through the
+            dedicated CryostatTab page. This tree only displays/logs its value.
+        '''
+        child = QtWidgets.QTreeWidgetItem()
+        item.addChild(child)
 
-                spin.setReadOnly(self.parameter_dic[device][param]['read'])
+        name_widget = QtWidgets.QLabel(param)
+        spin = QtWidgets.QDoubleSpinBox()
+        self.parameter_widgets[param] = spin
 
-                try:
-                    spin.setSuffix(self.parameter_dic[device][param]['unit'])
-                    spin.setMaximum(self.parameter_dic[device][param]['max'])
-                except Exception:
-                    pass
+        param_info = self.parameter_dic[device][param]
+        force_read_only = (device == 'cryostat')
+        spin.setReadOnly(param_info['read'] or force_read_only)
 
-                try:
-                    spin.setMinimum(self.parameter_dic[device][param]['min'])
-                except Exception:
-                    pass
+        try:
+            spin.setSuffix(param_info['unit'])
+            spin.setMaximum(param_info['max'])
+        except Exception:
+            pass
 
-                if self.parameter_dic[device][param]['read']:
-                    self.readonly_parameter.append(param)
-                else:
-                    spin.setValue(self.parameter_dic[device][param]['val'])
-                    spin.editingFinished.connect(
-                        partial(self.set_parameter, param)
-                    )
-                    self.writeonly_parameter.append(param)
+        try:
+            spin.setMinimum(param_info['min'])
+        except Exception:
+            pass
 
-                self.parameter_tree.setItemWidget(child, 0, name_widget)
-                self.parameter_tree.setItemWidget(child, 1, spin)
+        if param_info['read']:
+            self.readonly_parameter.append(param)
+        elif force_read_only:
+            spin.setValue(param_info['val'])
+            self.readonly_parameter.append(param)
+        else:
+            spin.setValue(param_info['val'])
+            spin.editingFinished.connect(partial(self.set_parameter, param))
+            self.writeonly_parameter.append(param)
 
-    
+        self.parameter_tree.setItemWidget(child, 0, name_widget)
+        self.parameter_tree.setItemWidget(child, 1, spin)
+
+
 
     def update_read_parameter(self, new_parameter):
         for param in new_parameter.keys():

--- a/src/main.py
+++ b/src/main.py
@@ -393,6 +393,16 @@ class MainInterface(QtWidgets.QMainWindow):
         # Rebuild parameter tree UI (existing code)
         self.create_parameter_array()
 
+        self.parameter = {}
+        for device in self.parameter_dic:
+            for param in self.parameter_dic[device]:
+                self.parameter[param] = self.parameter_dic[device][param]['val']
+        self.DataHandling.close()
+        self.DataHandling = DataHandling(self.parameter, self.spec_length)
+        self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
+        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
+        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+
         logger.info(
             f"Switched to spectrometer: {new_name} "
             f"(spec_length={self.spec_length})"

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from GUI.DelayCalibrationPlot import DelayCalibrationPlot, DelaySelectionPlot, D
 from GUI.MeasurementPlot import LOmeasurementPlot, MDCSmeasurementPlot, MDCSmeasurementFourierPlot
 from GUI.LUT_Calib_plot import LUT_Calib_plot, LUT_Calib_intensity_plot
 from GUI.SLMDisplay import SLMDisplay
+from GUI.CameraDisplay import CameraDisplay
 from DataHandling.DataHandling import DataHandling
 from measurements.MeasurementClasses import AcquireMeasurement,RunMeasurement,BackgroundMeasurement, ViewMeasurement
 from measurements.MDCSClasses import AcquireLO, BoxcarGeometry
@@ -256,7 +257,15 @@ class MainInterface(QtWidgets.QMainWindow):
         self.LUT_Calib_plot_2 = LUT_Calib_intensity_plot(self.LUT_calib_plot_layout_2)
         self.slm_display_plot= SLMDisplay(self.slm_display)
 
-        """ This initializes the parameter tree. It is constructed based on the device dict, 
+        """ Camera view tab. Built in code rather than in main_GUI.ui: the .ui file is edited by
+        several people in Qt Designer and merges badly, so a self-contained tab avoids conflicts.
+        The view is fed straight from the camera worker and deliberately bypasses DataHandling,
+        since it shows live 2D frames for alignment rather than measurement data. """
+        self.CameraDisplay = CameraDisplay()
+        self.tabWidget.addTab(self.CameraDisplay, 'Camera')
+        self.connect_camera_display()
+
+        """ This initializes the parameter tree. It is constructed based on the device dict,
         that includes parameter information of each device """
         self.parameter_tree.setColumnCount(2)
         self.parameter_tree.setHeaderLabels(["Name", "Value"])
@@ -403,11 +412,39 @@ class MainInterface(QtWidgets.QMainWindow):
         self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
         self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
 
+        self.connect_camera_display()
+
         logger.info(
             f"Switched to spectrometer: {new_name} "
             f"(spec_length={self.spec_length})"
-        )    
-        
+        )
+
+    def connect_camera_display(self):
+        '''
+            Points the Camera tab at the active spectrometer.
+            Cameras with a 2D sensor expose their raw frames through a worker signal; those frames are
+            routed straight to the view so alignment can be checked without going through DataHandling,
+            which only carries the 1D spectra used for measurements. Spectrometers without such a
+            worker simply leave the tab disabled.
+        '''
+        previous = getattr(self, '_camera_display_source', None)
+        if previous is not None:
+            try:
+                previous.sendSpectrum.disconnect(self.CameraDisplay.set_data)
+            except (TypeError, RuntimeError):
+                pass  # already disconnected or worker gone
+        self._camera_display_source = None
+
+        spectrometer = self.devices.get('spectrometer')
+        self.CameraDisplay.set_spectrometer(spectrometer)
+
+        worker = getattr(spectrometer, 'worker', None)
+        if worker is not None and hasattr(worker, 'sendSpectrum'):
+            worker.sendSpectrum.connect(self.CameraDisplay.set_data)
+            self._camera_display_source = worker
+            logger.info('%s Camera view connected to %s'
+                        % (datetime.datetime.now(), getattr(spectrometer, 'name', spectrometer)))
+
     def create_parameter_array(self):
         # initialization function to store all parameters in one array
 

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -564,13 +564,60 @@ class FitTemporalBeamCalibration(QtCore.QThread):
         # Loop through each wavelength 
         max_chirp_values = []
         wavelength_values = []
-        for wls in range(self.data.shape[1]):
-            intensity_column = self.data[:, wls]
-            max_row_index = np.argmax(intensity_column)
-            if max_row_index == 0:
-                continue
-            max_chirp_values.append(self.chirp_array[max_row_index])
-            wavelength_values.append(self.wavelength_array[wls])
+        # for wls in range(self.data.shape[1]):
+        #     intensity_column = self.data[:, wls]
+        #     max_row_index = np.argmax(intensity_column)
+        #     if max_row_index == 0:
+        #         continue
+        #     max_chirp_values.append(self.chirp_array[max_row_index])
+        #     wavelength_values.append(self.wavelength_array[wls])
+
+
+        # ----- Find starting wavelength -----
+        # wavelength with the strongest overall signal
+        start_col = np.argmax(np.max(self.data, axis=0))
+
+        # maximum there
+        start_row = np.argmax(self.data[:, start_col])
+
+        indices = np.zeros(self.data.shape[1], dtype=int)
+        indices[start_col] = start_row
+
+        # Search window in chirp units
+        window = 1000   # fs²/rad²
+
+        dchirp = np.abs(self.chirp_array[1] - self.chirp_array[0])
+        N = int(window / dchirp)
+
+        # ---------- Track toward longer wavelengths ----------
+        for col in range(start_col + 1, self.data.shape[1]):
+
+            prev = indices[col-1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # ---------- Track toward shorter wavelengths ----------
+        for col in range(start_col-1, -1, -1):
+
+            prev = indices[col+1]
+
+            lo = max(0, prev-N)
+            hi = min(self.data.shape[0], prev+N+1)
+
+            local = self.data[lo:hi, col]
+
+            indices[col] = lo + np.argmax(local)
+
+        # Final arrays
+        max_chirp_values = self.chirp_array[indices]
+        wavelength_values = self.wavelength_array
+
+
         max_chirp_values = np.array(max_chirp_values)
         wavelength_values = np.array(wavelength_values)
         omega_values = 0.5*co.waveToAngFreq(np.array(wavelength_values) * 1e-9) # rad Hz

--- a/src/measurements/CalibrationClasses.py
+++ b/src/measurements/CalibrationClasses.py
@@ -85,7 +85,7 @@ class VerticalBeamCalibrationMeasurement(QtCore.QThread):
                 self.vertical_calibration_data['intensities']=self.intensities
                 self.vertical_calibration_data['rows']=self.rows
                 if i>=1:
-                    self.send_intensities.emit(self.rows,self.intensities[1:])
+                    self.send_intensities.emit(self.rows,self.intensities)
         self.vertical_calibration_data['intensities']=self.intensities
         self.vertical_calibration_data['rows']=self.rows
         self.send_vertical_calibration_data.emit(('vertical_calibration_data',self.vertical_calibration_data))
@@ -423,11 +423,12 @@ class ChirpCalibrationMeasurement(QtCore.QThread):
                                 'data' : np.array(self.intensities)
                                 }
                             if i>=3:
-                                indexes = np.where(
-                                    (self.wls >= (self.carrierWls/2 - 100)) &
-                                    (self.wls <= (self.carrierWls/2 + 100))
-                                )[0]
-                                self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                # indexes = np.where(
+                                #     (self.wls >= (self.carrierWls/2 - 100)) &
+                                #     (self.wls <= (self.carrierWls/2 + 100))
+                                # )[0]
+                                # self.send_chirp.emit(self.chirp[3:i],self.wls[indexes],np.array(self.intensities)[3:i,indexes])
+                                self.send_chirp.emit(self.chirp[3:i],self.wls,np.array(self.intensities)[3:i,:])
         self.send_chirp_calibration_data.emit(('chirp_calibration_raw_data',self.Chirp_calibration_data))
         self.sendProgress.emit(100)
         self.stop()
@@ -775,6 +776,7 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         data_filtered_region = data_filtered[1:-1, mask]
         data_integrated = np.sum(data_filtered_region, axis=1)
         data_integrated_normalized = data_integrated/np.max(data_integrated)
+        data_integrated_normalized = -(data_integrated_normalized-np.max(data_integrated_normalized))
 
         self.sendCrossCorrelationRegion.emit(delay_array_region, data_integrated_normalized)
         self.delay_calibration_processed_data={
@@ -799,7 +801,8 @@ class DelayCalibrationMeasurement(QtCore.QThread):
         C0 = np.min(self.intensity)
 
         p0 = [A0, mu0, sigma0, C0]
-        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0)
+        bounds = ([-np.inf, self.delay.min(), 0, -np.inf], [ np.inf, self.delay.max(), np.inf, np.inf])
+        popt, pcov = curve_fit(lambda x, A, mu, sigma, C: A * np.exp(-(x - mu)**2 / (2 * sigma**2)) + C, self.delay, self.intensity, p0=p0, bounds=bounds)
         A, mu, sigma, C = popt
         self.fitted_intensity = (A * np.exp(-(self.delay - mu)**2 / (2 * sigma**2)) + C)
         self.sendCrossCorrelationRegionFit.emit(self.delay, self.fitted_intensity, mu, sigma)

--- a/src/measurements/MDCSClasses.py
+++ b/src/measurements/MDCSClasses.py
@@ -191,20 +191,20 @@ class BoxcarGeometry(QtCore.QThread):
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
                 'C' : self.t_secondary[i]*np.ones(Nb_step),
-                'B' : self.t_scanned,
+                'B' : self.t_scanned.copy(),
                 'LO' : self.t_scanned-self.t_LO*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - rephasing':
             self.group_delay = {
                 'A' : np.zeros(Nb_step),
-                'C' : self.t_scanned,
+                'C' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
         elif self.measurement_type == '1Q - non rephasing':
             self.group_delay = {
                 'C' : np.zeros(Nb_step),
-                'A' : self.t_scanned,
+                'A' : self.t_scanned.copy(),
                 'B' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
@@ -215,6 +215,17 @@ class BoxcarGeometry(QtCore.QThread):
                 'A' : self.t_scanned+self.t_secondary[i]*np.ones(Nb_step),
                 'LO' : self.t_scanned+(self.t_secondary[i]-self.t_LO)*np.ones(Nb_step)
             }
+        elif self.measurement_type == 'LO scan':
+            self.group_delay = {
+                'C' : np.zeros(Nb_step),
+                'B' : np.zeros(Nb_step),
+                'A' : np.zeros(Nb_step),
+                'LO' : self.t_scanned.copy()
+            }
+        
+        # To give the right delay between pulse
+        for key in self.group_delay:
+            self.group_delay[key] *= -1
 
     def phase_cycling(self, j):
         '''


### PR DESCRIPTION
## Summary
The Pixis camera ROI was hardcoded to a single sensor row (y=0, height=1), discarding ~99% of the signal on a spectrograph where the vertical axis is real spatial data. Replaces this with `set_roi()`/`set_binned_roi()`/`set_full_frame()` doing true on-chip binning. Adds a live Camera tab (2D view + signal-band detection) built on top of it, a standalone diagnostic script to find the real signal row range, and a startup-crash fix for when the monochromator isn't connected. Split from one bundled commit into 4 atomic ones for review; two follow-up fixes (crosshair-connection guard, view auto-fit on frame-shape change) are included as their own commits.

## Test plan
- Confirmed against the PIXIS system manual: hardware binning is genuinely done on-chip before the readout amplifier.
- Offscreen smoke test passes; startup no longer crashes without a monochromator connected.