### PR TITLE
Fix/pixis camera tab

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Binary files must never go through line-ending conversion. Committing the debugging report as a
+# PDF made git warn that LF would be replaced by CRLF, which would corrupt the file on checkout.
+*.pdf binary
+*.h5 binary
+*.dll binary
+*.png binary
+*.jpg binary
+*.stl binary
+*.lut binary

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -49,14 +49,19 @@ class DataHandling(QtCore.QThread):
         self.parameter_measured = np.zeros([len(self.parameter) + 2, 0])
 
         # preallocate data arrays depending on data dimension (1D or 2D).
+        """ The background is zeroed, not np.empty: an np.empty array holds whatever was in memory,
+        and subtracting it corrupts every spectrum silently. has_background says whether a real
+        background was ever measured or loaded; until then correct_background subtracts nothing. """
         if self.data_dim  == 1:
             self.spec = np.empty([self.speclength, 0])
-            self.background = np.empty([self.speclength, 1])
+            self.background = np.zeros([self.speclength, 1])
             self.wls = np.empty([self.speclength, 1])
         else:
             self.spec = np.empty([0,self.speclength[0],self.speclength[1]])
-            self.background = np.empty([0,self.speclength[0],self.speclength[1]])
+            self.background = np.zeros([1,self.speclength[0],self.speclength[1]])
             self.wls = np.empty([self.speclength[1], 1])
+        self.has_background = False
+        self.background_warned = False
 
         # set initial values
         self.maximum = np.zeros([3])
@@ -123,7 +128,7 @@ class DataHandling(QtCore.QThread):
         self.wls = wls
         if self.data_dim == 1:
             if self.correct_background:
-                spec = spec - self.background.ravel()
+                spec = self.subtract_background(spec)
             self.spec = np.c_[self.spec, spec]
 
         else:
@@ -155,6 +160,65 @@ class DataHandling(QtCore.QThread):
             self.maximum[2] = wls[np.unravel_index(spec.argmax(), spec.shape)[1]]
         self.maximum[0] = curr_time
         self.sendMaximum.emit(self.maximum)
+
+    def subtract_background(self, spec):
+        """
+            Subtracts the stored background, and refuses to do anything else.
+            Returns the spectrum unchanged, with one warning, when no background has been measured or
+            loaded, or when the stored one does not match the current spectrum length. Both used to go
+            through unnoticed: the background array was allocated with np.empty and no measurement ever
+            filled it, so ticking background correction subtracted uninitialised memory.
+            input:
+                - spec (np.ndarray): spectrum to correct
+            output:
+                - np.ndarray: corrected spectrum, or the original one if no valid background
+        """
+        reason = None
+        if not self.has_background:
+            reason = 'no background has been acquired or loaded'
+        elif self.background.size != np.size(spec):
+            reason = ('background is %d points, spectrum is %d'
+                      % (self.background.size, np.size(spec)))
+        if reason is not None:
+            if not self.background_warned:
+                logger.warning('%s Background correction is on but was not applied: %s'
+                               % (datetime.datetime.now(), reason))
+                self.background_warned = True
+            return spec
+        return spec - self.background.ravel()
+
+    def use_background(self, spec):
+        """
+            Adopts a spectrum as the background to subtract.
+            input:
+                - spec (np.ndarray): background spectrum. A file holding several spectra is accepted,
+                  in which case the last one is used, matching how load_bg used to slice it.
+            output:
+                - bool: whether a usable background was stored
+        """
+        flat = np.asarray(spec, dtype=float).ravel()
+        if self.data_dim == 1 and flat.size != self.speclength:
+            if self.speclength and flat.size % self.speclength == 0:
+                flat = flat[-self.speclength:]
+            else:
+                logger.error('%s Background rejected: %d points for a %s point spectrum'
+                             % (datetime.datetime.now(), flat.size, self.speclength))
+                return False
+        self.background = flat.reshape(-1, 1) if self.data_dim == 1 else np.asarray(spec, dtype=float)
+        self.has_background = True
+        self.background_warned = False
+        logger.info('%s Background stored (%d points)' % (datetime.datetime.now(), flat.size))
+        return True
+
+    @QtCore.pyqtSlot(np.ndarray, np.ndarray)
+    def set_background(self, wls, spec):
+        """
+            Slot for a background measurement, which emits wavelengths and intensities together.
+            input:
+                - wls (np.ndarray): wavelengths, unused
+                - spec (np.ndarray): measured background
+        """
+        self.use_background(spec)
 
     # save data to temp file and clear data in memory
     def save_buffer(self):
@@ -334,14 +398,21 @@ class DataHandling(QtCore.QThread):
         # preallocate data arrays depending on data dimension (1D or 2D).
         if self.data_dim == 1:
             self.spec = np.empty([self.speclength, 0])
-
-            self.background = np.empty([self.speclength, 1])
+            self.background = np.zeros([self.speclength, 1])
             self.wls = np.empty([self.speclength, 1])
         else:
             self.spec = np.empty([0, self.speclength[0], self.speclength[1]])
-
-            self.background = np.empty([0, self.speclength[0], self.speclength[1]])
+            self.background = np.zeros([1, self.speclength[0], self.speclength[1]])
             self.wls = np.empty([self.speclength[1], 1])
+
+        """ A background belongs to the spectrometer it was taken on, so changing spectrometer drops
+        it. It used to be reallocated with np.empty while the correction checkbox stayed ticked,
+        which silently turned a valid background into uninitialised memory. """
+        if self.has_background:
+            logger.warning('%s Background dropped: the spectrum length changed to %s'
+                           % (datetime.datetime.now(), self.speclength))
+        self.has_background = False
+        self.background_warned = False
 
         # Optional: log the update
         logger.info(f"Updated spec_length to {self.speclength} and reset buffers.")

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -128,8 +128,15 @@ class DataHandling(QtCore.QThread):
 
         else:
             self.spec = np.concatenate([self.spec, spec[np.newaxis, ...]])
+        """ A parameter only has a recorded value once update_parameter() has run for it. Reading
+        queue[-1] unconditionally raised IndexError on every spectrum, which killed this slot before
+        sendSpectrum was emitted: the measurement finished, the traceback went to stderr rather than
+        to the log, and no spectrum ever reached the plot. Parameters with nothing recorded keep
+        their previous value instead. """
         for idx, param in enumerate(self.parameter_queue.keys()):
-            self.param_from_deque[idx] = self.parameter_queue[param][-1]
+            queue = self.parameter_queue[param]
+            if queue:
+                self.param_from_deque[idx] = queue[-1]
         self.parameter_measured = np.c_[self.parameter_measured, self.param_from_deque]
         self.parameter_measured[0, -1] = curr_time
         self.parameter_measured[1, -1] = time.time()

--- a/src/DataHandling/DataHandling.py
+++ b/src/DataHandling/DataHandling.py
@@ -14,6 +14,7 @@ import numpy as np
 import os.path
 from collections import deque
 import shutil
+import threading
 import logging
 import datetime
 from numpy.polynomial import Polynomial as P
@@ -80,8 +81,12 @@ class DataHandling(QtCore.QThread):
         self.calibration = {}
 
         # initialize BufferWorker
+        """ The worker writes the buffer in its own thread. save_data() has to know when that write
+        has actually finished before it copies the file, so the worker signals completion through
+        this event. It used to sleep 0.5 s and hope. """
+        self.buffer_written = threading.Event()
         self.thread = QtCore.QThread()
-        self.BufferWorker = BufferWorker(self.temp_filename,self.data_dim)
+        self.BufferWorker = BufferWorker(self.temp_filename, self.data_dim, self.buffer_written)
         self.BufferWorker.moveToThread(self.thread)
         self.thread.start()
         self.bufferSaveSignal.connect(self.BufferWorker.save_buffer)
@@ -93,15 +98,27 @@ class DataHandling(QtCore.QThread):
         """ This is an important part of hardware parameter control. We use "deque" as efficient First-In-First-Out
         Queues that allow to have a continuous acces to the last 100.000 hardware parameters. Each parameter has their
         on deque object. Each time the update parameter function is called by the updater, the most updated value of the
-        hardware parameter is added to the deque"""
+        hardware parameter is added to the deque.
+            input:
+                - parameter (dict): parameter name -> current value. Names absent from the dictionary,
+                  and values that are not numbers such as the cryostat reporting "Stable", repeat the
+                  last recorded value so the columns stay aligned with the spectra.
+
+        This used to take a sequence indexed positionally, and nothing in the code ever called it.
+        The queues therefore stayed empty, which left parameter_measured full of zeros: no hardware
+        setting was ever stored beside the data it belongs to.
+        """
         self.parameter_queue['time'].append(time.time() - self.starttime)
         self.parameter_queue['absolute_time'].append(time.time())
 
-        for idx, param in enumerate(self.parameter):
-            self.parameter_queue[param].append(parameter[idx])
+        for param in self.parameter:
+            queue = self.parameter_queue[param]
+            try:
+                value = float(parameter[param])
+            except (KeyError, TypeError, ValueError):
+                value = queue[-1] if queue else 0.0
+            queue.append(value)
 
-        # for param, value in zip(self.parameter_queue, parameter):
-        #     self.parameter_queue[param].append(value)
         self.sendParameterarray.emit(np.array(self.parameter_queue[self.send_x_idx]), np.array(self.parameter_queue[self.send_y_idx]))
 
     def clear_data(self):
@@ -225,6 +242,7 @@ class DataHandling(QtCore.QThread):
         """ Saves data to a temporary file and populates it each time more than 100 spectra have been acquired.
         If the file is created, some attributes such as yaxis and parameter keys are added."""
         t1 = time.time()
+        self.buffer_written.clear()
         self.bufferSaveSignal.emit(self.spec, self.wls, self.parameter_queue, self.parameter_measured)
 
         # clear arrays in memory
@@ -253,7 +271,13 @@ class DataHandling(QtCore.QThread):
     def save_data(self, filename, comments):
         """saves data. Each time data is saved, parameters are saved aswell. """
         self.save_buffer()
-        time.sleep(0.5) # allow for BufferWorker to create temp file
+        """ Wait for the worker to finish writing rather than sleeping a fixed 0.5 s: on a large
+        buffer or a slow disk that sleep expired first and the file below was copied half written.
+        The timeout is long because it only has to cover a genuinely slow write. """
+        if not self.buffer_written.wait(timeout=60):
+            logger.error('%s Not saved: the buffer was still being written after 60 s'
+                         % datetime.datetime.now())
+            return
         with h5py.File(self.temp_filename, 'a') as hf:
             hf.attrs["comments"] = comments
             if len(self.calibration) > 0 :
@@ -463,10 +487,11 @@ class BufferWorker(QtCore.QObject):
     """ Buffer worker saves data to a temp file.
     It is started every time a given amount of data has been acquired and receives signals with the corresponding data"""
 
-    def __init__(self,temp_filename, data_dim):
+    def __init__(self, temp_filename, data_dim, done_event=None):
         super(BufferWorker, self).__init__()
         self.temp_filename = temp_filename
         self.data_dim = data_dim
+        self.done_event = done_event
         self.firstbuffer = True
         self.terminate = False
         # check if folder for buffer exists
@@ -511,3 +536,7 @@ class BufferWorker(QtCore.QObject):
                     hf["parameter"][:, -parameter_measured.shape[1]:] = parameter_measured
             except TypeError:
                 logger.warning('% s Saving failed. Did you already save?' %datetime.datetime.now())
+        """ Release save_data(). Left unset if the write above raised, so save_data() times out and
+        refuses to copy rather than copying a half-written file. """
+        if self.done_event is not None:
+            self.done_event.set()

--- a/src/GUI/AcquisitionSettings.py
+++ b/src/GUI/AcquisitionSettings.py
@@ -13,6 +13,7 @@ Timers are entered with a unit and their effect is shown in Hz and in total acqu
 """
 
 from PyQt5 import QtWidgets, QtCore
+from functools import partial
 import logging
 
 from drivers.Stresing import (TRIGGER_INPUTS, CHOPPER_INPUTS,
@@ -21,6 +22,10 @@ from drivers.Stresing import (TRIGGER_INPUTS, CHOPPER_INPUTS,
 logger = logging.getLogger(__name__)
 
 UNITS_US = {'us': 1, 'ms': 1000, 's': 1000000}
+
+""" Parameters this panel already presents in a friendlier form, and which must therefore not be
+repeated as raw spin boxes in the camera group. """
+PANEL_OWNED = ('No_Sample', 'No_Block', 'Scan_Trig', 'Block_Trig', 'Scan_Timer', 'Block_Timer')
 
 
 class AcquisitionSettings(QtWidgets.QWidget):
@@ -177,6 +182,19 @@ class AcquisitionSettings(QtWidgets.QWidget):
         mono_layout.setColumnStretch(2, 1)
         self.mono_box.setLayout(mono_layout)
 
+        # ---- camera parameters ----
+        """ The camera's own settings, built from the driver's parameter_display_dict so this works
+        for any spectrometer without naming its parameters here. The Hardware tree shows the same
+        values read-only: control belongs next to the acquisition settings it affects, not in a tree
+        shared with every other device. """
+        self.camera_box = QtWidgets.QGroupBox('Camera')
+        self.camera_layout = QtWidgets.QGridLayout()
+        self.camera_box.setLayout(self.camera_layout)
+        self.camera_widgets = {}
+        """ Set by the main window so a change made here also reaches the value it records with the
+        data and the read-only row in the tree. """
+        self.parameter_changed = None
+
         # ---- summary and actions ----
         self.summary_label = QtWidgets.QLabel()
         self.summary_label.setWordWrap(True)
@@ -215,10 +233,11 @@ class AcquisitionSettings(QtWidgets.QWidget):
         layout.addWidget(self.structure_box, 1, 1)
         layout.addWidget(self.source_box, 2, 0)
         layout.addWidget(self.mono_box, 2, 1)
-        layout.addWidget(self.summary_label, 3, 0, 1, 2)
-        layout.addWidget(self.registers_label, 4, 0, 1, 2)
-        layout.addLayout(actions, 5, 0, 1, 2)
-        layout.setRowStretch(6, 1)
+        layout.addWidget(self.camera_box, 3, 0, 1, 2)
+        layout.addWidget(self.summary_label, 4, 0, 1, 2)
+        layout.addWidget(self.registers_label, 5, 0, 1, 2)
+        layout.addLayout(actions, 6, 0, 1, 2)
+        layout.setRowStretch(7, 1)
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
         self.setLayout(layout)
@@ -249,6 +268,10 @@ class AcquisitionSettings(QtWidgets.QWidget):
                 - spectrometer: camera driver, or None to disable the panel
         """
         self.spectrometer = spectrometer
+        """ Built for every camera, including those with no configurable trigger: the trigger boxes
+        below may end up disabled, the camera's own settings stay usable. """
+        self.build_camera_parameters(spectrometer)
+
         supported = spectrometer is not None and hasattr(spectrometer, 'set_acquisition_mode')
         """ Only the camera side is disabled: the monochromator is shared by every spectrometer and
         stays usable whichever camera is selected. """
@@ -280,6 +303,69 @@ class AcquisitionSettings(QtWidgets.QWidget):
         self.scans_per_block.setValue(getattr(spectrometer, 'sample', 10))
         self.blocks.setValue(getattr(spectrometer, 'block', 1))
         self.mode_changed()
+
+    def build_camera_parameters(self, spectrometer):
+        """
+            Rebuilds the camera controls from the driver's own parameter declaration.
+            input:
+                - spectrometer: camera driver, or None to leave the group empty
+        """
+        while self.camera_layout.count():
+            widget = self.camera_layout.takeAt(0).widget()
+            if widget is not None:
+                widget.deleteLater()
+        self.camera_widgets = {}
+
+        display = getattr(spectrometer, 'parameter_display_dict', None) or {}
+        row = 0
+        for name, info in display.items():
+            if name in PANEL_OWNED:
+                continue
+            spin = QtWidgets.QDoubleSpinBox()
+            spin.setMinimumWidth(90)
+            spin.setMaximumWidth(140)
+            for key, setter in (('unit', spin.setSuffix), ('max', spin.setMaximum),
+                                ('min', spin.setMinimum), ('val', spin.setValue)):
+                try:
+                    setter(info[key])
+                except (KeyError, TypeError):
+                    pass
+            if info.get('read'):
+                """ A reading, not a setting: shown so the value is visible next to the controls that
+                depend on it, but the driver has nothing to set it to. """
+                spin.setReadOnly(True)
+                spin.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+            else:
+                spin.editingFinished.connect(partial(self.apply_camera_parameter, name))
+            self.camera_layout.addWidget(QtWidgets.QLabel('%s:' % name), row // 2, (row % 2) * 2)
+            self.camera_layout.addWidget(spin, row // 2, (row % 2) * 2 + 1)
+            self.camera_widgets[name] = spin
+            row += 1
+
+        self.camera_layout.setColumnStretch(4, 1)
+        self.camera_box.setVisible(bool(self.camera_widgets))
+
+    def apply_camera_parameter(self, name):
+        """
+            Pushes one camera parameter to the driver.
+            input:
+                - name (str): parameter name as the driver declares it
+        """
+        if self.spectrometer is None or name not in self.camera_widgets:
+            return
+        if callable(self.is_busy) and self.is_busy():
+            self.status_label.setText('A measurement is running. Stop it before changing %s.' % name)
+            return
+        value = self.camera_widgets[name].value()
+        try:
+            self.spectrometer.set_parameter(name, value)
+        except Exception as e:
+            logger.error('Could not set %s: %s', name, e)
+            self.status_label.setText('Could not set %s: %s' % (name, e))
+            return
+        self.status_label.setText('%s set to %g.' % (name, value))
+        if callable(self.parameter_changed):
+            self.parameter_changed(name, value)
 
     def set_monochromator(self, monochromator):
         """

--- a/src/GUI/AcquisitionSettings.py
+++ b/src/GUI/AcquisitionSettings.py
@@ -1,0 +1,494 @@
+"""
+Acquisition settings for the Stresing camera, expressed as a mode rather than as raw registers.
+
+The board is configured through two trigger registers, sti (what starts one readout) and bti (what
+starts one block of readouts). They share the numbering of the external inputs but diverge above 4,
+each has a timer that only applies in one of its modes, and both are counts of microseconds. Shown
+as eight independent spin boxes this is unusable: nothing says that Scan_Timer is ignored unless
+Scan_Trig is exactly 4, and nothing says what the numbers mean.
+
+This widget exposes the three setups the experiment actually uses -- the board running on its own
+timer, one readout per laser pulse, and blocks gated by a chopper -- and derives sti/bti from that.
+Timers are entered with a unit and their effect is shown in Hz and in total acquisition time.
+"""
+
+from PyQt5 import QtWidgets, QtCore
+import logging
+
+from drivers.Stresing import (TRIGGER_INPUTS, CHOPPER_INPUTS,
+                              CONTINUOUS, EXTERNAL, CHOPPER)
+
+logger = logging.getLogger(__name__)
+
+UNITS_US = {'us': 1, 'ms': 1000, 's': 1000000}
+
+
+class AcquisitionSettings(QtWidgets.QWidget):
+    """
+        Trigger and timing controls for a camera exposing set_acquisition_mode().
+    """
+
+    settings_applied = QtCore.pyqtSignal()
+
+    def __init__(self, spectrometer=None, parent=None):
+        """
+            Builds the panel.
+            input:
+                - spectrometer: camera driver exposing set_acquisition_mode/get_acquisition_mode
+                  (currently Stresing). None leaves the controls disabled.
+                - parent: parent widget
+        """
+        super(AcquisitionSettings, self).__init__(parent)
+        self.spectrometer = None
+        self.monochromator = None
+        """ Set by the main window to a callable telling whether a measurement is running. Applying
+        re-initialises the measurement on the board from the GUI thread, which would block the
+        interface if the board were still busy with the previous acquisition. """
+        self.is_busy = None
+
+        # ---- mode ----
+        self.mode_continuous = QtWidgets.QRadioButton('Continuous (internal timer)')
+        self.mode_continuous.setToolTip('The board triggers itself on its internal timer.\n'
+                                        'Use this to check alignment or to test without the laser.')
+        self.mode_external = QtWidgets.QRadioButton('Synchronised to laser')
+        self.mode_external.setToolTip('One readout per pulse on a trigger input of the PCIe board.')
+        self.mode_chopper = QtWidgets.QRadioButton('Chopper')
+        self.mode_chopper.setToolTip('Blocks are gated by a chopper signal, for shot to shot\n'
+                                     'referencing between pumped and unpumped spectra.')
+        self.mode_continuous.setChecked(True)
+
+        self.mode_box = QtWidgets.QGroupBox('Trigger mode')
+        mode_layout = QtWidgets.QVBoxLayout()
+        for widget in (self.mode_continuous, self.mode_external, self.mode_chopper):
+            mode_layout.addWidget(widget)
+            widget.toggled.connect(self.mode_changed)
+        mode_layout.addStretch(1)
+        self.mode_box.setLayout(mode_layout)
+
+        # ---- timing ----
+        self.scan_interval = QtWidgets.QDoubleSpinBox()
+        self.scan_interval.setRange(0.001, 1000000)
+        self.scan_interval.setDecimals(2)
+        self.scan_interval.setValue(10)
+        self.scan_unit = QtWidgets.QComboBox()
+        self.scan_unit.addItems(list(UNITS_US.keys()))
+        self.scan_unit.setCurrentText('ms')
+        self.scan_rate_label = QtWidgets.QLabel()
+
+        self.block_interval = QtWidgets.QDoubleSpinBox()
+        self.block_interval.setRange(0.001, 1000000)
+        self.block_interval.setDecimals(2)
+        self.block_interval.setValue(300)
+        self.block_unit = QtWidgets.QComboBox()
+        self.block_unit.addItems(list(UNITS_US.keys()))
+        self.block_unit.setCurrentText('ms')
+
+        self.timing_box = QtWidgets.QGroupBox('Timing')
+        timing_layout = QtWidgets.QGridLayout()
+        timing_layout.addWidget(QtWidgets.QLabel('Spectrum interval:'), 0, 0)
+        timing_layout.addWidget(self.scan_interval, 0, 1)
+        timing_layout.addWidget(self.scan_unit, 0, 2)
+        timing_layout.addWidget(self.scan_rate_label, 0, 3)
+        timing_layout.addWidget(QtWidgets.QLabel('Block interval:'), 1, 0)
+        timing_layout.addWidget(self.block_interval, 1, 1)
+        timing_layout.addWidget(self.block_unit, 1, 2)
+        timing_layout.setColumnStretch(3, 1)
+        self.timing_box.setLayout(timing_layout)
+
+        # ---- trigger source ----
+        self.trigger_input = QtWidgets.QComboBox()
+        self.trigger_input.addItems(list(TRIGGER_INPUTS.keys()))
+        self.trigger_input.setToolTip('Connector on the PCIe board carrying the trigger.')
+        self.chopper_input = QtWidgets.QComboBox()
+        self.chopper_input.addItems(list(CHOPPER_INPUTS.keys()))
+        self.scan_on_timer = QtWidgets.QCheckBox('Read out on internal timer')
+        self.scan_on_timer.setToolTip('Chopper gates the blocks, while the readouts inside a block\n'
+                                      'run on the internal timer instead of a trigger input.')
+        self.timeout = QtWidgets.QDoubleSpinBox()
+        self.timeout.setRange(0.1, 3600)
+        self.timeout.setDecimals(1)
+        self.timeout.setValue(5)
+        self.timeout.setSuffix(' s')
+        self.timeout.setToolTip('Give up if no scan arrives within this time, instead of waiting\n'
+                                'forever on a trigger that is not coming.')
+
+        self.source_box = QtWidgets.QGroupBox('Trigger source')
+        source_layout = QtWidgets.QGridLayout()
+        source_layout.addWidget(QtWidgets.QLabel('Input:'), 0, 0)
+        source_layout.addWidget(self.trigger_input, 0, 1)
+        source_layout.addWidget(self.chopper_label(), 1, 0)
+        source_layout.addWidget(self.chopper_input, 1, 1)
+        source_layout.addWidget(self.scan_on_timer, 2, 0, 1, 2)
+        source_layout.addWidget(QtWidgets.QLabel('Timeout:'), 3, 0)
+        source_layout.addWidget(self.timeout, 3, 1)
+        source_layout.setColumnStretch(2, 1)
+        self.source_box.setLayout(source_layout)
+
+        # ---- structure ----
+        self.scans_per_block = QtWidgets.QSpinBox()
+        self.scans_per_block.setRange(6, 100000)
+        self.scans_per_block.setValue(10)
+        self.scans_per_block.setToolTip('Readouts averaged into one spectrum (nos).')
+        self.blocks = QtWidgets.QSpinBox()
+        self.blocks.setRange(1, 100000)
+        self.blocks.setValue(1)
+        self.blocks.setToolTip('Number of blocks (nob).')
+
+        self.structure_box = QtWidgets.QGroupBox('Acquisition structure')
+        structure_layout = QtWidgets.QGridLayout()
+        structure_layout.addWidget(QtWidgets.QLabel('Spectra / block:'), 0, 0)
+        structure_layout.addWidget(self.scans_per_block, 0, 1)
+        structure_layout.addWidget(QtWidgets.QLabel('Blocks:'), 1, 0)
+        structure_layout.addWidget(self.blocks, 1, 1)
+        structure_layout.setColumnStretch(2, 1)
+        self.structure_box.setLayout(structure_layout)
+
+        # ---- monochromator ----
+        self.center_wavelength = QtWidgets.QDoubleSpinBox()
+        self.center_wavelength.setRange(200, 1100)
+        self.center_wavelength.setDecimals(2)
+        self.center_wavelength.setSuffix(' nm')
+        self.center_wavelength.setToolTip('Wavelength at the centre of the sensor. Moves the grating.')
+        self.grating_choice = QtWidgets.QComboBox()
+
+        """ The exit mirror decides which camera receives the light at all, which is worth naming
+        after the cameras rather than after the mirror positions. Checked on the bench with a HeNe:
+        front sends the beam to the Pixis, side to the Stresing. ?MIR reports 0 and 1 respectively. """
+        self.exit_port = QtWidgets.QComboBox()
+        self.exit_port.addItem('Stresing (side)', 1)
+        self.exit_port.addItem('Pixis (front)', 0)
+        self.exit_port.setToolTip('Which exit port of the spectrograph the light leaves by.\n'
+                                  'The camera on the other port sees nothing.')
+
+        self.apply_mono_button = QtWidgets.QPushButton('Move optics')
+        self.mono_status = QtWidgets.QLabel()
+        self.mono_status.setWordWrap(True)
+
+        self.mono_box = QtWidgets.QGroupBox('Monochromator')
+        mono_layout = QtWidgets.QGridLayout()
+        mono_layout.addWidget(QtWidgets.QLabel('Wavelength:'), 0, 0)
+        mono_layout.addWidget(self.center_wavelength, 0, 1)
+        mono_layout.addWidget(QtWidgets.QLabel('Grating:'), 1, 0)
+        mono_layout.addWidget(self.grating_choice, 1, 1)
+        mono_layout.addWidget(QtWidgets.QLabel('Light to:'), 2, 0)
+        mono_layout.addWidget(self.exit_port, 2, 1)
+        mono_layout.addWidget(self.apply_mono_button, 3, 0, 1, 2)
+        mono_layout.addWidget(self.mono_status, 4, 0, 1, 2)
+        mono_layout.setColumnStretch(2, 1)
+        self.mono_box.setLayout(mono_layout)
+
+        # ---- summary and actions ----
+        self.summary_label = QtWidgets.QLabel()
+        self.summary_label.setWordWrap(True)
+        self.registers_label = QtWidgets.QLabel()
+        self.registers_label.setWordWrap(True)
+        self.registers_label.setToolTip('What this writes to the board, in the vocabulary of\n'
+                                        'config_UdeM.ini and of the Stresing documentation.')
+        self.apply_button = QtWidgets.QPushButton('Apply')
+        self.status_label = QtWidgets.QLabel()
+        self.status_label.setWordWrap(True)
+
+        """ Minimum widths so the panel asks the splitter for the room it needs. Squeezed below these
+        the radio labels and combo entries are clipped to nothing, which is what the first version of
+        this layout did. """
+        for widget in (self.trigger_input, self.chopper_input, self.grating_choice):
+            widget.setMinimumWidth(130)
+            widget.setMaximumWidth(170)
+        for widget in (self.scan_interval, self.block_interval, self.scans_per_block,
+                       self.blocks, self.timeout, self.center_wavelength):
+            widget.setMinimumWidth(80)
+            widget.setMaximumWidth(110)
+        for widget in (self.scan_unit, self.block_unit):
+            widget.setMinimumWidth(60)
+
+        actions = QtWidgets.QHBoxLayout()
+        actions.addWidget(self.apply_button)
+        actions.addWidget(self.status_label, stretch=1)
+
+        """ Two columns rather than one tall stack: the panel shares its row with the camera view, so
+        it has to stay short enough to need no scrolling, and it is the width that is available. Boxes
+        that are only shown in some modes sit in the left column, so hiding them does not leave a gap
+        in the middle of the panel. """
+        layout = QtWidgets.QGridLayout()
+        layout.addWidget(self.mode_box, 0, 0, 2, 1)
+        layout.addWidget(self.timing_box, 0, 1)
+        layout.addWidget(self.structure_box, 1, 1)
+        layout.addWidget(self.source_box, 2, 0)
+        layout.addWidget(self.mono_box, 2, 1)
+        layout.addWidget(self.summary_label, 3, 0, 1, 2)
+        layout.addWidget(self.registers_label, 4, 0, 1, 2)
+        layout.addLayout(actions, 5, 0, 1, 2)
+        layout.setRowStretch(6, 1)
+        layout.setColumnStretch(0, 1)
+        layout.setColumnStretch(1, 1)
+        self.setLayout(layout)
+
+        # ---- connections ----
+        self.apply_button.clicked.connect(self.apply_settings)
+        self.apply_mono_button.clicked.connect(self.apply_monochromator)
+        for widget in (self.scan_interval, self.block_interval, self.scans_per_block, self.blocks):
+            widget.valueChanged.connect(self.refresh_summary)
+        for widget in (self.scan_unit, self.block_unit, self.trigger_input, self.chopper_input):
+            widget.currentIndexChanged.connect(self.refresh_summary)
+        self.scan_on_timer.toggled.connect(self.refresh_summary)
+
+        self.set_spectrometer(spectrometer)
+
+    def chopper_label(self):
+        """
+            Builds the chopper row label, kept as a method so it can be hidden with its combo box.
+        """
+        self._chopper_label = QtWidgets.QLabel('Chopper:')
+        return self._chopper_label
+
+    def set_spectrometer(self, spectrometer):
+        """
+            Attaches the camera this panel configures, and reads its current setup back into the
+            controls.
+            input:
+                - spectrometer: camera driver, or None to disable the panel
+        """
+        self.spectrometer = spectrometer
+        supported = spectrometer is not None and hasattr(spectrometer, 'set_acquisition_mode')
+        """ Only the camera side is disabled: the monochromator is shared by every spectrometer and
+        stays usable whichever camera is selected. """
+        for box in (self.mode_box, self.timing_box, self.source_box, self.structure_box):
+            box.setEnabled(supported)
+        self.apply_button.setEnabled(supported)
+        if not supported:
+            self.status_label.setText('Active spectrometer has no configurable trigger. '
+                                      'This tab applies to the Stresing camera.')
+            return
+
+        try:
+            current = spectrometer.get_acquisition_mode()
+        except Exception as e:
+            logger.warning('Could not read the Stresing trigger setup: %s', e)
+            self.mode_changed()
+            return
+
+        self.mode_continuous.setChecked(current['mode'] == CONTINUOUS)
+        self.mode_external.setChecked(current['mode'] == EXTERNAL)
+        self.mode_chopper.setChecked(current['mode'] == CHOPPER)
+        self.set_interval(self.scan_interval, self.scan_unit, current['scan_interval_us'])
+        self.set_interval(self.block_interval, self.block_unit, current['block_interval_us'])
+        self.scan_on_timer.setChecked(current['scan_trigger'] == 'timer')
+        if current['scan_trigger'] in TRIGGER_INPUTS:
+            self.trigger_input.setCurrentText(current['scan_trigger'])
+        self.chopper_input.setCurrentText(current['chopper'])
+        self.timeout.setValue(current['timeout_s'])
+        self.scans_per_block.setValue(getattr(spectrometer, 'sample', 10))
+        self.blocks.setValue(getattr(spectrometer, 'block', 1))
+        self.mode_changed()
+
+    def set_monochromator(self, monochromator):
+        """
+            Attaches the monochromator whose grating and centre wavelength this panel drives.
+            input:
+                - monochromator: driver exposing set_parameter('central_wave'/'grating'), or None
+        """
+        self.monochromator = monochromator
+        supported = monochromator is not None and hasattr(monochromator, 'set_parameter')
+        self.mono_box.setEnabled(supported)
+        if not supported:
+            self.mono_status.setText('No monochromator connected.')
+            return
+
+        """ grating_densities is read back from the instrument and its last entries can be padding
+        rather than real gratings, so only plausible groove densities are offered. """
+        self.grating_choice.clear()
+        for index, density in enumerate(getattr(monochromator, 'grating_densities', []), start=1):
+            if density >= 50:
+                self.grating_choice.addItem('%d  (%d lines/mm)' % (index, density), index)
+
+        current = int(getattr(monochromator, 'grating', 1))
+        position = self.grating_choice.findData(current)
+        if position >= 0:
+            self.grating_choice.setCurrentIndex(position)
+        self.center_wavelength.setValue(float(getattr(monochromator, 'center_wl', 0.0)))
+
+        position = self.exit_port.findData(int(getattr(monochromator, 'mirror', 1)))
+        if position >= 0:
+            self.exit_port.setCurrentIndex(position)
+        self.mono_status.setText('')
+
+    def apply_monochromator(self):
+        """
+            Moves the grating and the centre wavelength. Both are slow mechanical moves, so they are
+            applied on their own button rather than with the trigger settings.
+        """
+        if self.monochromator is None or not hasattr(self.monochromator, 'set_parameter'):
+            return
+        if callable(self.is_busy) and self.is_busy():
+            self.mono_status.setText('A measurement is running. Stop it before moving the grating.')
+            return
+        grating = self.grating_choice.currentData()
+        port = self.exit_port.currentData()
+        try:
+            """ Only moved when it actually changes: both are slow mechanical moves, and the grating
+            in particular takes seconds to settle. """
+            if grating is not None and grating != int(getattr(self.monochromator, 'grating', 0)):
+                self.monochromator.set_parameter('grating', grating)
+            self.monochromator.set_parameter('central_wave', self.center_wavelength.value())
+            if port is not None and port != int(getattr(self.monochromator, 'mirror', -1)):
+                self.monochromator.set_parameter('mirror', port)
+        except Exception as e:
+            logger.error('Could not move the monochromator: %s', e)
+            self.mono_status.setText('Could not move: %s' % e)
+            return
+        self.mono_status.setText('%.2f nm, light to %s.'
+                                 % (self.center_wavelength.value(), self.exit_port.currentText()))
+        self.settings_applied.emit()
+
+    def set_interval(self, spin, unit, microseconds):
+        """
+            Fills an interval control with the largest unit that keeps the number readable.
+            input:
+                - spin (QDoubleSpinBox): value control
+                - unit (QComboBox): unit control
+                - microseconds (int): interval to display
+        """
+        microseconds = max(float(microseconds), 0.001)
+        for name in ('s', 'ms', 'us'):
+            if microseconds >= UNITS_US[name]:
+                unit.setCurrentText(name)
+                spin.setValue(microseconds / UNITS_US[name])
+                return
+        unit.setCurrentText('us')
+        spin.setValue(microseconds)
+
+    def current_mode(self):
+        """
+            Returns the selected mode.
+        """
+        if self.mode_external.isChecked():
+            return EXTERNAL
+        if self.mode_chopper.isChecked():
+            return CHOPPER
+        return CONTINUOUS
+
+    def scan_interval_us(self):
+        """
+            Returns the readout interval in microseconds.
+        """
+        return self.scan_interval.value() * UNITS_US[self.scan_unit.currentText()]
+
+    def block_interval_us(self):
+        """
+            Returns the block interval in microseconds.
+        """
+        return self.block_interval.value() * UNITS_US[self.block_unit.currentText()]
+
+    def readouts_on_timer(self):
+        """
+            True when the readouts themselves run on the internal timer, which is always the case in
+            continuous mode and optional under a chopper.
+        """
+        mode = self.current_mode()
+        return mode == CONTINUOUS or (mode == CHOPPER and self.scan_on_timer.isChecked())
+
+    def mode_changed(self):
+        """
+            Shows only the controls the selected mode actually uses. The timers are hidden rather
+            than greyed when the board ignores them, so no value on screen is a value with no effect.
+        """
+        mode = self.current_mode()
+        on_timer = self.readouts_on_timer()
+
+        self.timing_box.setVisible(on_timer or mode == CONTINUOUS)
+        self.scan_interval.setEnabled(on_timer)
+        self.scan_unit.setEnabled(on_timer)
+        self.scan_rate_label.setEnabled(on_timer)
+        self.block_interval.setEnabled(mode == CONTINUOUS)
+        self.block_unit.setEnabled(mode == CONTINUOUS)
+
+        self.source_box.setVisible(mode != CONTINUOUS)
+        self.trigger_input.setVisible(mode == EXTERNAL or (mode == CHOPPER and not on_timer))
+        self._chopper_label.setVisible(mode == CHOPPER)
+        self.chopper_input.setVisible(mode == CHOPPER)
+        self.scan_on_timer.setVisible(mode == CHOPPER)
+
+        self.refresh_summary()
+
+    def refresh_summary(self):
+        """
+            Recomputes the derived readouts: readout rate, total number of spectra, expected
+            duration, and the registers this will write.
+        """
+        mode = self.current_mode()
+        nos, nob = self.scans_per_block.value(), self.blocks.value()
+
+        scan_us = self.scan_interval_us()
+        if self.readouts_on_timer() and scan_us > 0:
+            self.scan_rate_label.setText('= %d Hz' % round(1000000.0 / scan_us))
+        else:
+            self.scan_rate_label.setText('')
+
+        if mode == CONTINUOUS:
+            total_us = nos * scan_us * nob
+            duration = ('%.1f s' % (total_us / 1000000.0) if total_us >= 1000000
+                        else '%d ms' % round(total_us / 1000.0))
+            self.summary_label.setText('This acquisition: %d spectra averaged, about %s.'
+                                       % (nos * nob, duration))
+        elif mode == EXTERNAL:
+            self.summary_label.setText(
+                'This acquisition: %d spectra averaged, at the rate of the laser. '
+                'Needs %d trigger pulses on input %s.'
+                % (nos * nob, nos * nob, self.trigger_input.currentText()))
+        else:
+            self.summary_label.setText(
+                'This acquisition: %d spectra averaged, %d block%s gated by the chopper on %s.'
+                % (nos * nob, nob, '' if nob == 1 else 's', self.chopper_input.currentText()))
+
+        self.registers_label.setText('Writes: %s' % self.registers_preview(mode, nos, nob))
+
+    def registers_preview(self, mode, nos, nob):
+        """
+            Describes the registers the current selection maps to, in the vocabulary of
+            config_UdeM.ini.
+            input:
+                - mode (str): selected mode
+                - nos (int): spectra per block
+                - nob (int): number of blocks
+        """
+        if mode == CONTINUOUS:
+            return ('sti=4, stimer=%d, bti=4, btimer=%d, nos=%d, nob=%d'
+                    % (round(self.scan_interval_us()), round(self.block_interval_us()), nos, nob))
+        if mode == EXTERNAL:
+            source = TRIGGER_INPUTS[self.trigger_input.currentText()]
+            return 'sti=%d, bti=%d, nos=%d, nob=%d (timers unused)' % (source, source, nos, nob)
+        bti = CHOPPER_INPUTS[self.chopper_input.currentText()]
+        if self.scan_on_timer.isChecked():
+            return ('sti=4, stimer=%d, bti=%d, nos=%d, nob=%d'
+                    % (round(self.scan_interval_us()), bti, nos, nob))
+        sti = TRIGGER_INPUTS[self.trigger_input.currentText()]
+        return 'sti=%d, bti=%d, nos=%d, nob=%d (timers unused)' % (sti, bti, nos, nob)
+
+    def apply_settings(self):
+        """
+            Pushes the selection to the camera.
+        """
+        if self.spectrometer is None or not hasattr(self.spectrometer, 'set_acquisition_mode'):
+            return
+        if callable(self.is_busy) and self.is_busy():
+            self.status_label.setText('A measurement is running. Stop it before changing the trigger.')
+            return
+        mode = self.current_mode()
+        scan_trigger = ('timer' if mode == CHOPPER and self.scan_on_timer.isChecked()
+                        else self.trigger_input.currentText())
+        try:
+            self.spectrometer.set_parameter('No_Sample', self.scans_per_block.value())
+            self.spectrometer.set_parameter('No_Block', self.blocks.value())
+            self.spectrometer.set_acquisition_mode(
+                mode,
+                scan_trigger=scan_trigger,
+                chopper=self.chopper_input.currentText(),
+                scan_interval_us=self.scan_interval_us(),
+                block_interval_us=self.block_interval_us(),
+                timeout_s=self.timeout.value())
+        except Exception as e:
+            logger.error('Could not apply the Stresing acquisition settings: %s', e)
+            self.status_label.setText('Could not apply: %s' % e)
+            return
+        self.status_label.setText('Applied.')
+        self.settings_applied.emit()

--- a/src/GUI/CameraDisplay.py
+++ b/src/GUI/CameraDisplay.py
@@ -252,13 +252,20 @@ class CameraDisplay(QtWidgets.QWidget):
         try:
             if self.mode_full_frame.isChecked():
                 self.spectrometer.set_full_frame()
-                self.status_label.setText('Full frame readout applied (alignment mode).')
+                y0, height = 0, int(getattr(self.spectrometer, 'sensor_height', 1))
+                self.status_label.setText(
+                    'Full frame readout applied (alignment mode). Counts are the sum of every row, '
+                    'so they are far larger than in binned mode.')
             else:
                 y0, height = self.y0_spin.value(), self.height_spin.value()
                 self.spectrometer.set_binned_roi(y0, height)
                 self.status_label.setText(
-                    f'Binned readout applied: rows {y0} to {y0 + height - 1} summed on chip.')
-                self.roi_applied.emit(y0, height)
+                    f'Binned readout applied: rows {y0} to {y0 + height - 1} summed on chip. '
+                    'The on-chip sum saturates at the converter limit, so counts are much lower '
+                    'than the full frame sum and the two must not be compared.')
+            """ Announced for both modes: the spectrum plot has to be cleared, since the counts of
+            one mode dwarf the other and a leftover curve makes the new one look flat at zero. """
+            self.roi_applied.emit(y0, height)
             self._auto_levels_pending = True
         except Exception as e:
             logger.error('Failed to apply Pixis ROI: %s', e)

--- a/src/GUI/SpectrometerPlot.py
+++ b/src/GUI/SpectrometerPlot.py
@@ -30,15 +30,10 @@ class SpectrometerPlot(QtWidgets.QMainWindow):
         # add firstplot for Acquire mode
         self.first_plot = True
 
-        # create random example data set
-        sigma = 40
-        mu = 2
-        wls = np.array(np.linspace(177.2218, 884.00732139, 512))
-        spec = np.random.randint(0, 100, 512) + 20000./ (sigma * np.sqrt(2. * np.pi)) * np.exp(- (wls - mu - 620.) ** 2. / (2. * sigma ** 2.)) - 50,
-        flatspec = np.array(spec)
-
-        # plot data: x, y values
-        self.graphWidget.plot(wls.reshape(-1), flatspec.reshape(-1),pen =pg.mkPen([200,200,200], width = 2))
+        """ The plot starts empty. It used to be seeded with a random gaussian spanning 177 to 884 nm,
+        which stayed on the plot and stretched the axes over that whole range: a real spectrum from
+        the Stresing covers about 48 nm, so it was squeezed into a narrow strip and read as nothing
+        being displayed. """
         self.graphWidget.getAxis('left').setStyle(tickFont = fontForTickValues)
         self.graphWidget.getAxis('bottom').setStyle(tickFont = fontForTickValues)
         self.graphWidget.setLabel('left', 'Intensity (counts)', **styles)

--- a/src/GUI/SpectrometerPlot.py
+++ b/src/GUI/SpectrometerPlot.py
@@ -102,10 +102,16 @@ class SpectrometerPlot(QtWidgets.QMainWindow):
 
     def update_crosshair(self, e):
         pos = e[0]
-        if self.graphWidget.sceneBoundingRect().contains(pos):
-            mousePoint = self.graphWidget.getPlotItem().vb.mapSceneToView(pos)
-            self.crosshair_v.setPos(mousePoint.x())
-            self.crosshair_h.setPos(mousePoint.y())
+        """ Everything below needs mousePoint, which only exists while the pointer is over this plot.
+        The label was updated unconditionally, so every mouse move outside the plot raised
+        UnboundLocalError. Harmless in itself, but it floods stderr and buries real tracebacks, and
+        there are now two spectrum plots, so the one that is not under the cursor raised on every
+        move. """
+        if not self.graphWidget.sceneBoundingRect().contains(pos):
+            return
+        mousePoint = self.graphWidget.getPlotItem().vb.mapSceneToView(pos)
+        self.crosshair_v.setPos(mousePoint.x())
+        self.crosshair_h.setPos(mousePoint.y())
         calibration_mode = False
         if calibration_mode:
             pixel = np.argmin(abs(self.wls - mousePoint.x()))

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -21,6 +21,7 @@ import numpy as np
 from PyQt5 import QtCore
 from collections import defaultdict
 from pylablib.devices import PrincetonInstruments
+import threading
 import time
 import re
 
@@ -76,6 +77,12 @@ class Pixis(QtCore.QThread):
         print(PrincetonInstruments.list_cameras())
         self.camera = PrincetonInstruments.PicamCamera()
         print('Camera connected')
+
+        """ The camera is driven from two threads: the measurement thread through get_intensities(),
+        and the GUI thread through set_roi() when a readout region is applied. Interleaving those
+        made PICam fail with AcquisitionInProgress. Reentrant because set_roi() starts and stops the
+        acquisition while already holding the lock. """
+        self.camera_lock = threading.RLock()
 
         # Determine the number of sensor rows available for vertical binning.
         # The PIXIS used here is 1024 x 256, but ask the camera rather than assume.
@@ -228,19 +235,22 @@ class Pixis(QtCore.QThread):
         # PICam requires the region height to be an exact multiple of the binning factor
         height = max((height // binning) * binning, binning)
 
-        was_acquiring = getattr(self, 'worker', None) is not None and self.worker.acquiring
-        if was_acquiring:
-            self.stop_acquisition()
+        """ Held for the whole sequence: stopping, reconfiguring and restarting must not interleave
+        with the measurement thread starting its own acquisition. """
+        with self.camera_lock:
+            was_acquiring = getattr(self, 'worker', None) is not None and self.worker.acquiring
+            if was_acquiring:
+                self.stop_acquisition()
 
-        roi = {"x": 0, "width": 1024, "x_binning": 1,
-               "y": y0, "height": height, "y_binning": binning}
-        self.camera.set_attribute_value("ROIs", [roi])
-        self.roi_y0, self.roi_height, self.roi_binning = y0, height, binning
-        print(f'Pixis ROI: rows {y0}-{y0 + height - 1} of {self.sensor_height}, '
-              f'binning {binning} -> {height // binning} row(s) read out')
+            roi = {"x": 0, "width": 1024, "x_binning": 1,
+                   "y": y0, "height": height, "y_binning": binning}
+            self.camera.set_attribute_value("ROIs", [roi])
+            self.roi_y0, self.roi_height, self.roi_binning = y0, height, binning
+            print(f'Pixis ROI: rows {y0}-{y0 + height - 1} of {self.sensor_height}, '
+                  f'binning {binning} -> {height // binning} row(s) read out')
 
-        if was_acquiring and restart:
-            self.start_acquisition()
+            if was_acquiring and restart:
+                self.start_acquisition()
         return roi
 
     def set_binned_roi(self, y0, height):
@@ -267,36 +277,75 @@ class Pixis(QtCore.QThread):
         """
         return self.roi_y0, self.roi_height, self.roi_binning
 
+    def acquisition_running(self):
+        """
+            Whether the camera itself considers an acquisition to be running. Falls back to the
+            worker flag if the driver does not expose the query.
+        """
+        try:
+            return bool(self.camera.acquisition_in_progress())
+        except Exception:
+            # set_roi() runs once before the worker exists, hence the nested getattr.
+            return bool(getattr(getattr(self, 'worker', None), 'acquiring', False))
+
     def start_acquisition(self):
-        """ Sets camera to continuous acquisition mode. """
-        self.camera.start_acquisition()
-        self.worker.acquiring = True
+        """
+            Sets camera to continuous acquisition mode.
+            Idempotent and serialised: PICam raises AcquisitionInProgress when asked to start while
+            it is already running. That happened whenever a readout region was applied during a live
+            view, because set_roi() and get_intensities() drive the camera from two different threads.
+        """
+        with self.camera_lock:
+            if not self.acquisition_running():
+                self.camera.start_acquisition()
+            self.worker.acquiring = True
 
     def stop_acquisition(self):
-        """ Disable continuous acquisition mode of camera. """
-        self.worker.acquiring = False
-        self.camera.stop_acquisition()
+        """
+            Disable continuous acquisition mode of camera.
+        """
+        with self.camera_lock:
+            self.worker.acquiring = False
+            if self.acquisition_running():
+                self.camera.stop_acquisition()
+
+    def wait_for_frame(self):
+        """
+            Blocks until the worker delivers the next frame, and returns it.
+            The wait used to be an unbounded `while not self.new_spectrum`, so a readout region
+            applied mid-acquisition, or a camera that simply stopped delivering, hung the measurement
+            thread with no way back. The allowance is ten exposures plus five seconds, which is
+            generous next to the 150 ms the camera normally needs.
+            output:
+                - np.ndarray: the frame received
+        """
+        allowance = max(self.int_time / 1000.0, 0.1) * 10 + 5
+        deadline = time.time() + allowance
+        while not self.new_spectrum:
+            if time.time() > deadline:
+                raise TimeoutError('Pixis delivered no frame within %.1f s (exposure %s ms)'
+                                   % (allowance, self.int_time))
+            time.sleep(0.01)
+        frame = self.spectrum
+        self.new_spectrum = False
+        return frame
 
     def get_intensities(self):
         """ Gets the intensity. The example include the possibility of averaging several spectra and to
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
         self.start_acquisition()
-        if self.avg_scan == 1:
-            while not self.new_spectrum:
-                time.sleep(0.01)
-            spectrum = self.spectrum
-            self.new_spectrum = False
-        else:
-            spectrum = self.image
-            for i in range(self.avg_scan):
-                time.sleep(self.int_time / 1000 + 0.01)
-                while not self.new_spectrum:
-                    time.sleep(0.01)
-                spectrum = spectrum + self.spectrum
-                self.new_spectrum = False
-            spectrum = spectrum / self.avg_scan
-        self.stop_acquisition()
+        try:
+            if self.avg_scan == 1:
+                spectrum = self.wait_for_frame()
+            else:
+                spectrum = self.image
+                for i in range(self.avg_scan):
+                    time.sleep(self.int_time / 1000 + 0.01)
+                    spectrum = spectrum + self.wait_for_frame()
+                spectrum = spectrum / self.avg_scan
+        finally:
+            self.stop_acquisition()
         """ The camera returns one row per binning group: a single row in binned (measurement) mode,
         every sensor row in full frame (alignment) mode. Any remaining rows are summed here so both
         modes hand back a 1D spectrum. Counts therefore scale with the number of rows summed, which
@@ -345,10 +394,14 @@ class CameraWorker(QtCore.QThread):
                 while not type(image) == np.ndarray and not time.time() > timeout_start + self.int_time/1E3 + 0.5:
                     time.sleep(0.02)
                     image = self.camera.read_newest_image()
-                try:
+                """ read_newest_image() returns None when nothing arrived before the deadline above.
+                Emitting that raised TypeError, which was caught and reported as "Spectrum not sent
+                from Worker" -- a message that named neither the cause nor the camera state. """
+                if isinstance(image, np.ndarray):
                     self.sendSpectrum.emit(image, self.int_time)
-                except TypeError:
-                    print('WARNING: Spectrum not sent from Worker')
+                else:
+                    print('Pixis: no frame within %.2f s (exposure %s ms). Is the acquisition running?'
+                          % (self.int_time / 1E3 + 0.5, self.int_time))
             else:
                 time.sleep(1)
             temperature = self.camera.get_attribute_value("Sensor Temperature Reading")

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -65,7 +65,10 @@ class Pixis(QtCore.QThread):
         self.parameter_display_dict['sensor_T']['unit'] = ' celsius'
         self.parameter_display_dict['sensor_T']['min'] = -100
         self.parameter_display_dict['sensor_T']['max'] = 100
-        self.parameter_display_dict['sensor_T']['read'] = False
+        """ A reading, not a setting: set_parameter() has no branch for it, and the worker is what
+        updates it. Declaring it writable put it among the parameters the updater does not poll, so
+        the temperature on screen never changed after startup. """
+        self.parameter_display_dict['sensor_T']['read'] = True
 
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}

--- a/src/drivers/Pixis.py
+++ b/src/drivers/Pixis.py
@@ -116,7 +116,7 @@ class Pixis(QtCore.QThread):
         self.worker.start()
 
         # set int time once
-        self.camera.set_attribute_value("Exposure Time", int(self.int_time))
+        self.camera.set_attribute_value("Exposure Time", float(self.int_time))
 
     def set_parameter(self, parameter, value):
         """REQUIRED. This function defines how changes in the parameter tree are handled.
@@ -126,10 +126,10 @@ class Pixis(QtCore.QThread):
             self.worker.int_time = value
             if self.worker.acquiring: # stops acquisition before changing int time if currently acquiring.
                 self.stop_acquisition()
-                self.camera.set_attribute_value("Exposure Time", int(value))
+                self.camera.set_attribute_value("Exposure Time", float(value))
                 self.start_acquisition()
             else:
-                self.camera.set_attribute_value("Exposure Time", int(value))
+                self.camera.set_attribute_value("Exposure Time", float(value))
             self.int_time = value
         elif parameter == 'avg_scan':
             self.parameter_dict['avg_scan'] = value
@@ -299,6 +299,12 @@ class Pixis(QtCore.QThread):
             view, because set_roi() and get_intensities() drive the camera from two different threads.
         """
         with self.camera_lock:
+            """ If the camera reports an acquisition while the worker was not reading, the two are
+            out of step: that acquisition was set up under the previous readout region and delivers
+            nothing here. Stop it and start again rather than adopting it, which is what left
+            get_intensities() waiting for a frame that never came after a region change. """
+            if self.acquisition_running() and not self.worker.acquiring:
+                self.camera.stop_acquisition()
             if not self.acquisition_running():
                 self.camera.start_acquisition()
             self.worker.acquiring = True
@@ -338,6 +344,10 @@ class Pixis(QtCore.QThread):
         perform a binning. Such functionalities might also be given by the camera.
         This function will be accessible from MeasurementClasses."""
         self.start_acquisition()
+        """ Drop anything the worker delivered before this call. A frame can arrive just after the
+        previous acquisition was stopped, and it was taken with the readout region in force then:
+        consuming it here would return the old region's data for the new one. """
+        self.new_spectrum = False
         try:
             if self.avg_scan == 1:
                 spectrum = self.wait_for_frame()

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -14,7 +14,6 @@ set_parameter function (assign set functions)
 import numpy as np
 from PyQt5 import QtCore
 from collections import defaultdict
-import time
 from pathlib import Path
 import matplotlib.pyplot as plt
 from drivers.StresingDriver import camera_settings
@@ -27,6 +26,19 @@ import logging
 import datetime
 
 logger = logging.getLogger(__name__)
+
+""" Trigger sources the board understands, as documented in StresingDriver.init_driver(). sti and bti
+share the numbering for the external inputs but diverge above 4, so they are listed separately rather
+than exposed as raw numbers. """
+TRIGGER_INPUTS = {'I': 0, 'S1': 1, 'S2': 2, 'I gated by S2': 3}
+TRIGGER_TIMER = 4
+CHOPPER_INPUTS = {'S1': 5, 'S2': 6, 'S1 and S2': 7}
+
+CONTINUOUS = 'continuous'
+EXTERNAL = 'external'
+CHOPPER = 'chopper'
+
+
 class StresingCamera(QtCore.QThread):
 
     name = 'StresingCamera'
@@ -35,9 +47,11 @@ class StresingCamera(QtCore.QThread):
         super(StresingCamera, self).__init__()
 
         # initialize Worker
+        """ The worker is kept as the signal carrier that publishes each acquired spectrum, but its
+        thread is not started: the readout is a pull, driven by get_intensities() from the measurement
+        thread, so a polling loop has nothing to do. Not starting it also avoids leaving a thread
+        running at shutdown. """
         self.worker = StresingWorker()
-        self.worker.sendSpectrum.connect(self.update_spectrum) # connect where signals of worker go to.
-        self.worker.start()
         self.type = 'Camera'
 
         # This is the hardware parameters dictionnary. It is provided by hardware-specific configurations and are not changed in operation
@@ -84,6 +98,10 @@ class StresingCamera(QtCore.QThread):
         self.btimer = int(float(config.get("Board0","btimer")))
         self.stimer = int(config.get("Board0","stimer"))
         self.new_spectrum = False
+
+        """ Deadline used when the board is waiting on an external signal. Without it a trigger that
+        never arrives leaves the acquisition thread stuck inside the DLL with no way back. """
+        self.trigger_timeout_s = 5.0
 
         # set parameter dict
         self.parameter_dict = defaultdict()
@@ -248,10 +266,6 @@ class StresingCamera(QtCore.QThread):
             self.new_spectrum = False
         init_measure(self) # type: ignore
 
-    def update_spectrum(self, spectrum):
-        self.spectrum = spectrum
-        self.new_spectrum = True
-
     def calculate_wavelength_array(self):
         """
             Calculate the wavelength array for the pixels of the Stresing camera using the hardware parameters from the camera and the attached monochromator. 
@@ -321,6 +335,86 @@ class StresingCamera(QtCore.QThread):
         self.type='Spectrometer'
         self.hardware_params.update(self.monochromator.get_hardware_parameters('Stresing'))
 
+    def get_acquisition_mode(self):
+        """
+            Returns the current trigger setup in the vocabulary the interface uses, so a widget can
+            show the mode rather than the raw sti/bti register values.
+        """
+        if self.bti in CHOPPER_INPUTS.values():
+            mode = CHOPPER
+        elif self.sti == TRIGGER_TIMER and self.bti == TRIGGER_TIMER:
+            mode = CONTINUOUS
+        else:
+            mode = EXTERNAL
+        inputs = {v: k for k, v in TRIGGER_INPUTS.items()}
+        choppers = {v: k for k, v in CHOPPER_INPUTS.items()}
+        return {'mode': mode,
+                'scan_trigger': 'timer' if self.sti == TRIGGER_TIMER else inputs.get(self.sti, 'I'),
+                'chopper': choppers.get(self.bti, 'S1'),
+                'scan_interval_us': self.stimer,
+                'block_interval_us': self.btimer,
+                'timeout_s': self.trigger_timeout_s}
+
+    def set_acquisition_mode(self, mode, scan_trigger='I', chopper='S1',
+                             scan_interval_us=None, block_interval_us=None, timeout_s=None):
+        """
+            Sets sti, bti and their timers as one coherent choice instead of four loose registers.
+            input:
+                - mode (str): CONTINUOUS (the board drives itself), EXTERNAL (one readout per trigger
+                  pulse) or CHOPPER (blocks gated by a chopper signal)
+                - scan_trigger (str): key of TRIGGER_INPUTS, or 'timer', for what starts a readout.
+                  Ignored in CONTINUOUS.
+                - chopper (str): key of CHOPPER_INPUTS. Only used in CHOPPER.
+                - scan_interval_us (int): time between readouts, applied only when readouts run on
+                  the internal timer
+                - block_interval_us (int): time between blocks, applied only in CONTINUOUS
+                - timeout_s (float): how long to wait for an external signal before giving up
+        """
+        if mode == CONTINUOUS:
+            sti = bti = TRIGGER_TIMER
+        elif mode == EXTERNAL:
+            sti = bti = TRIGGER_INPUTS[scan_trigger]
+        elif mode == CHOPPER:
+            bti = CHOPPER_INPUTS[chopper]
+            sti = TRIGGER_TIMER if scan_trigger == 'timer' else TRIGGER_INPUTS[scan_trigger]
+        else:
+            raise ValueError('Unknown acquisition mode: %s' % mode)
+
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        cam.sti_mode, cam.bti_mode = sti, bti
+        self.sti, self.bti = sti, bti
+
+        """ The board only reads a timer in the mode that uses it. Writing them in the other modes
+        would leave values on screen that have no effect, which is what made the old parameter table
+        misleading. """
+        if sti == TRIGGER_TIMER and scan_interval_us:
+            cam.stime_in_microsec = int(scan_interval_us)
+            self.stimer = int(scan_interval_us)
+        if bti == TRIGGER_TIMER and block_interval_us:
+            cam.btime_in_microsec = int(block_interval_us)
+            self.btimer = int(block_interval_us)
+        if timeout_s is not None:
+            self.trigger_timeout_s = float(timeout_s)
+
+        # Keep the generic parameter tree in step with what was set here.
+        for key, value in (('Scan_Trig', self.sti), ('Block_Trig', self.bti),
+                           ('Scan_Timer', self.stimer), ('Block_Timer', self.btimer)):
+            self.parameter_dict[key] = value
+            self.parameter_display_dict[key]['val'] = value
+
+        self.new_spectrum = False
+        init_measure(self) # type: ignore
+        logger.info('%s Stresing acquisition mode: %s (sti=%d, bti=%d)'
+                    % (datetime.datetime.now(), mode, sti, bti))
+
+    def waits_for_external_signal(self):
+        """
+            True when either trigger depends on a signal the board does not generate itself, i.e.
+            when an acquisition can legitimately never complete.
+        """
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        return cam.sti_mode != TRIGGER_TIMER or cam.bti_mode != TRIGGER_TIMER
+
     def get_num_pixel(self):
         return self.hardware_params['num_pixels']
 
@@ -332,21 +426,34 @@ class StresingCamera(QtCore.QThread):
         return self.wavelengths
 
     def get_intensities(self):
-        use_blocking_call = True
-        self.spectrum = StresingWorker.worker_spectrum(self, use_blocking_call)
-        while not self.new_spectrum:
-            time.sleep(0.01)
-            self.new_spectrum = False
+        """ The blocking DLL call cannot be interrupted, so it is only used when the board drives
+        itself and the scans are guaranteed to come. Anything waiting on an external signal goes
+        through the polling path, which honours trigger_timeout_s. """
+        use_blocking_call = not self.waits_for_external_signal()
+        self.acquire_spectrum(use_blocking_call)
         self.spec = np.array(self.spectrum[13:-1])
         self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
+        """ Publish the same data the caller gets, so a live view can follow the acquisition without
+        going through DataHandling. """
+        self.worker.sendSpectrum.emit(self.spec)
         return self.spec
 
+    def acquire_spectrum(self, use_blocking_call):
+        """
+            Reads one spectrum off the board, in the calling thread.
+            input:
+                - use_blocking_call (bool): whether to wait in the DLL until the readout is complete
+        """
+        init_measure(self) # type: ignore
+        timeout_s = None if use_blocking_call else self.trigger_timeout_s
+        self.spectrum = measure(self, use_blocking_call, timeout_s) # type: ignore
+        self.new_spectrum = True
+
 class StresingWorker(QtCore.QThread):
-    """ This is a DemoWorker for the Stresing Camera.
-    It continously acquires spectra and emits them to the Interface.
-    It interrupts data acquisition if an ac_time change is requested. Its important because most
-    hardware can only handle one command at a time, acquiring or changing settings.  """
+    """ Publishes the spectra acquired from the Stresing camera to the interface.
+    The camera is read synchronously by StresingCamera.acquire_spectrum() in the thread that asks for
+    a spectrum, so this worker carries the signal only and its thread is never started. """
     # These are signals that allow to send data from a child thread to the parent hierarchy.
     sendSpectrum = QtCore.pyqtSignal(np.ndarray)
 
@@ -354,20 +461,7 @@ class StresingWorker(QtCore.QThread):
         super(StresingWorker, self).__init__() # Elevates this thread to be independent.
         self.new_spectrum = False
 
-    def run(self):
-        while True:
-            time.sleep(0.01)
-            if self.new_spectrum:
-                self.new_spectrum = False
-                self.sendSpectrum.emit(self.spectrum)
-            pass
 
-    def worker_spectrum(self, use_blocking_call):
-        init_measure(self) # type: ignore
-        self.spectrum = measure(self, use_blocking_call) # type: ignore
-        self.new_spectrum = True
-        return self.spectrum
-    
 class CaseInsensitiveConfig(configparser.ConfigParser):
     """ This class extends Python’s built-in configparser.ConfigParser to make both section names and option names case-insensitive.
     Normally, ConfigParser is only case-insensitive for option names, not section names, so this subclass enforces lowercase normalization for both. """

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -426,11 +426,7 @@ class StresingCamera(QtCore.QThread):
         return self.wavelengths
 
     def get_intensities(self):
-        """ The blocking DLL call cannot be interrupted, so it is only used when the board drives
-        itself and the scans are guaranteed to come. Anything waiting on an external signal goes
-        through the polling path, which honours trigger_timeout_s. """
-        use_blocking_call = not self.waits_for_external_signal()
-        self.acquire_spectrum(use_blocking_call)
+        self.acquire_spectrum()
         self.spec = np.array(self.spectrum[13:-1])
         self.spec = self.spec[::-1]
         #self.spec[:12] = 0 # Removes the first indexes (special pixels of the camera)
@@ -439,15 +435,35 @@ class StresingCamera(QtCore.QThread):
         self.worker.sendSpectrum.emit(self.spec)
         return self.spec
 
-    def acquire_spectrum(self, use_blocking_call):
+    def expected_duration_s(self):
+        """
+            How long one acquisition should take when the board drives itself, from the timers it was
+            given. Used to size the deadline, so a stalled board is caught in proportion to what the
+            settings actually ask for.
+        """
+        cam = self.driver.settings.camera_settings[self.driver.drvno]
+        scans, blocks = max(int(self.sample), 1), max(int(self.block), 1)
+        seconds = 0.0
+        if cam.sti_mode == TRIGGER_TIMER:
+            seconds += scans * blocks * self.stimer / 1e6
+        if cam.bti_mode == TRIGGER_TIMER:
+            seconds += blocks * self.btimer / 1e6
+        return seconds
+
+    def acquire_spectrum(self):
         """
             Reads one spectrum off the board, in the calling thread.
-            input:
-                - use_blocking_call (bool): whether to wait in the DLL until the readout is complete
+            Always polls with a deadline. The blocking DLL call cannot be interrupted and has been
+            seen never to return when the board is in a bad state, which hangs whichever thread asked
+            for the spectrum with no way back -- including the interface itself. Waiting on the board
+            is not worth losing the ability to give up.
         """
         init_measure(self) # type: ignore
-        timeout_s = None if use_blocking_call else self.trigger_timeout_s
-        self.spectrum = measure(self, use_blocking_call, timeout_s) # type: ignore
+        if self.waits_for_external_signal():
+            timeout_s = self.trigger_timeout_s
+        else:
+            timeout_s = max(self.expected_duration_s() * 3, 5.0)
+        self.spectrum = measure(self, False, timeout_s) # type: ignore
         self.new_spectrum = True
 
 class StresingWorker(QtCore.QThread):

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -459,11 +459,11 @@ class StresingCamera(QtCore.QThread):
             is not worth losing the ability to give up.
         """
         init_measure(self) # type: ignore
-        if self.waits_for_external_signal():
-            timeout_s = self.trigger_timeout_s
-        else:
-            timeout_s = max(self.expected_duration_s() * 3, 5.0)
-        self.spectrum = measure(self, False, timeout_s) # type: ignore
+        """ Only an acquisition that depends on an external signal needs the trigger watch. On the
+        internal timer the board drives itself and the readouts are guaranteed, so waiting for a
+        trigger there would just add a delay to every spectrum. """
+        timeout_s = self.trigger_timeout_s if self.waits_for_external_signal() else None
+        self.spectrum = measure(self, True, timeout_s) # type: ignore
         self.new_spectrum = True
 
 class StresingWorker(QtCore.QThread):

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -194,15 +194,42 @@ def abort_measure(self):
     self.dll.DLLAbortMeasurement()
 
 
-def measure(self, use_blocking_call, timeout_s=None):
+def wait_for_trigger(self, timeout_s):
+    """
+        Waits until the board reports a scan trigger, and raises if none appears.
+        Used before committing to the blocking start, which cannot be interrupted: this way an
+        input with no signal on it is reported instead of freezing the caller.
+        input:
+            - timeout_s (float): how long to wait for the first trigger
+    """
+    """ Both take a pointer to the flag as their second argument. Calling them with the board number
+    alone compiles and runs, and corrupts memory: it cost an access violation to find out. """
+    detected = ctypes.c_uint8(0)
+    ptr_detected = ctypes.pointer(detected)
+    self.dll.DLLResetScanTriggerDetected(self.drvno, ptr_detected)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        self.dll.DLLGetScanTriggerDetected(self.drvno, ptr_detected)
+        if detected.value:
+            break
+        if time.monotonic() > deadline:
+            self.dll.DLLOpenShutter(self.drvno)
+            raise TimeoutError(
+                'No trigger detected after %.1f s. The board is configured to start its readouts '
+                'on an external signal (sti=%d) and nothing is arriving on that input.'
+                % (timeout_s, self.settings.camera_settings[self.drvno].sti_mode))
+        time.sleep(0.001)
+
+
+def measure(self, use_blocking_call=True, timeout_s=None):
     """
         Runs one measurement and returns the spectrum averaged over samples and blocks.
         input:
-            - use_blocking_call (bool): wait inside the DLL until every scan is collected. Only safe
-              when the scans are guaranteed to come, i.e. on the internal timer.
-            - timeout_s (float): non-blocking path only. Gives up after this many seconds if the
-              board is still waiting for scans, instead of hanging forever on a trigger that never
-              arrives. None waits indefinitely.
+            - use_blocking_call (bool): kept for compatibility. The non-blocking start returns
+              'An unknown error occurred' on this board, checked against the instrument, so the
+              blocking call is the only one that actually starts a measurement.
+            - timeout_s (float): when set, wait this long for a trigger before starting. Leave None
+              when the board drives itself, where the readouts are guaranteed to come.
     """
     """ Clear a measurement the board may still be running from a previous attempt. Without this an
     acquisition that was aborted, timed out or killed leaves the board busy, and every later one
@@ -216,34 +243,16 @@ def measure(self, use_blocking_call, timeout_s=None):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
-    if use_blocking_call:
-        # Start the measurement. This is the blocking call, which means it will return when the measurement is finished. This is done to ensure that no data access happens before all data is collected.
-        status = self.dll.DLLStartMeasurement_blocking()
-        if(status != 0):
-            raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
-    else:
-        # Start the measurement. This is the nonblocking call, which means it will return immediately.
-        self.dll.DLLStartMeasurement_nonblocking()
+    """ The blocking call has no way out, so anything that depends on an external signal waits for a
+    trigger to actually appear first. On the internal timer the measurement takes as long as the
+    timers say -- 0.11 s for ten readouts at 10 ms, measured -- and is entered directly. """
+    if timeout_s is not None:
+        wait_for_trigger(self, timeout_s)
 
-        cur_sample = ctypes.c_int64(-2)
-        ptr_cur_sample = ctypes.pointer(cur_sample)
-        cur_block = ctypes.c_int64(-2)
-        ptr_cur_block = ctypes.pointer(cur_block)
-
-        deadline = None if timeout_s is None else time.monotonic() + timeout_s
-        while cur_sample.value < self.settings.nos-1 or cur_block.value < self.settings.nob-1:
-            self.dll.DLLGetCurrentScanNumber(self.drvno, ptr_cur_sample, ptr_cur_block)
-            if deadline is not None and time.monotonic() > deadline:
-                abort_measure(self)
-                self.dll.DLLOpenShutter(self.drvno)
-                raise TimeoutError(
-                    'No scan received after %.1f s (scan %d of %d, block %d of %d). '
-                    'The board is waiting for a trigger that is not arriving.'
-                    % (timeout_s, cur_sample.value + 1, self.settings.nos,
-                       cur_block.value + 1, self.settings.nob))
-            """ Yield the CPU: this loop used to spin flat out on one core while printing every
-            poll. """
-            time.sleep(0.001)
+    # This is the blocking call: it returns once the measurement is finished, so no data is read before it is all collected.
+    status = self.dll.DLLStartMeasurement_blocking()
+    if(status != 0):
+        raise RuntimeError(self.dll.DLLConvertErrorCodeToMsg(status))
 
     # This block is showing you how to get all data of the whole measurement with one DLL call
     data_buffer = (ctypes.c_uint16 * (self.settings.camera_settings[self.drvno].PIXEL * (self.settings.nos) * self.settings.camera_settings[self.drvno].CAMCNT * self.settings.nob))(0)

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -8,6 +8,7 @@ Created on Wed Jun  5 10:52:39 2024
 import ctypes
 import os
 import configparser
+import time
 import numpy as np
 
 # These are the settings structs. It must be the same like in EBST_CAM/shared_src/struct.h regarding order, data formats and size.
@@ -175,8 +176,27 @@ def init_measure(self):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
-def measure(self, use_blocking_call):
+def abort_measure(self):
+    """
+        Asks the board to drop a measurement that is still waiting for scans. Best effort: older DLL
+        builds do not export a stop function, in which case there is nothing to call.
+    """
+    try:
+        self.dll.DLLStopMeasurement(self.drvno)
+    except AttributeError:
+        pass
 
+
+def measure(self, use_blocking_call, timeout_s=None):
+    """
+        Runs one measurement and returns the spectrum averaged over samples and blocks.
+        input:
+            - use_blocking_call (bool): wait inside the DLL until every scan is collected. Only safe
+              when the scans are guaranteed to come, i.e. on the internal timer.
+            - timeout_s (float): non-blocking path only. Gives up after this many seconds if the
+              board is still waiting for scans, instead of hanging forever on a trigger that never
+              arrives. None waits indefinitely.
+    """
     # The sensor S14290 is a high speed sensor and is not completely cleared by one read out.
     # Therefore it may not be used without a reset signal, or following readouts have a crosstalk.
     status = self.dll.DLLCloseShutter(self.drvno)
@@ -189,7 +209,7 @@ def measure(self, use_blocking_call):
         if(status != 0):
             raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
     else:
-        # Start the measurement. This is the nonblocking call, which means it will return immediately. 
+        # Start the measurement. This is the nonblocking call, which means it will return immediately.
         self.dll.DLLStartMeasurement_nonblocking()
 
         cur_sample = ctypes.c_int64(-2)
@@ -197,9 +217,20 @@ def measure(self, use_blocking_call):
         cur_block = ctypes.c_int64(-2)
         ptr_cur_block = ctypes.pointer(cur_block)
 
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
         while cur_sample.value < self.settings.nos-1 or cur_block.value < self.settings.nob-1:
             self.dll.DLLGetCurrentScanNumber(self.drvno, ptr_cur_sample, ptr_cur_block)
-            print("sample: "+str(cur_sample.value)+" block: "+str(cur_block.value))
+            if deadline is not None and time.monotonic() > deadline:
+                abort_measure(self)
+                self.dll.DLLOpenShutter(self.drvno)
+                raise TimeoutError(
+                    'No scan received after %.1f s (scan %d of %d, block %d of %d). '
+                    'The board is waiting for a trigger that is not arriving.'
+                    % (timeout_s, cur_sample.value + 1, self.settings.nos,
+                       cur_block.value + 1, self.settings.nob))
+            """ Yield the CPU: this loop used to spin flat out on one core while printing every
+            poll. """
+            time.sleep(0.001)
 
     # This block is showing you how to get all data of the whole measurement with one DLL call
     data_buffer = (ctypes.c_uint16 * (self.settings.camera_settings[self.drvno].PIXEL * (self.settings.nos) * self.settings.camera_settings[self.drvno].CAMCNT * self.settings.nob))(0)

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -176,15 +176,22 @@ def init_measure(self):
     if(status != 0):
         raise BaseException(self.dll.DLLConvertErrorCodeToMsg(status))
 
+def measurement_running(self):
+    """
+        Whether the board still considers a measurement to be in progress.
+    """
+    return bool(self.dll.DLLGetIsRunning())
+
+
 def abort_measure(self):
     """
-        Asks the board to drop a measurement that is still waiting for scans. Best effort: older DLL
-        builds do not export a stop function, in which case there is nothing to call.
+        Stops a measurement the board is still running.
+        The export is DLLAbortMeasurement. An earlier version of this called DLLStopMeasurement,
+        which this DLL does not export, and swallowed the resulting AttributeError: every timeout
+        therefore left the board running, and the next acquisition either failed with 'Measurement
+        is already running' or blocked with no way out.
     """
-    try:
-        self.dll.DLLStopMeasurement(self.drvno)
-    except AttributeError:
-        pass
+    self.dll.DLLAbortMeasurement()
 
 
 def measure(self, use_blocking_call, timeout_s=None):
@@ -197,6 +204,12 @@ def measure(self, use_blocking_call, timeout_s=None):
               board is still waiting for scans, instead of hanging forever on a trigger that never
               arrives. None waits indefinitely.
     """
+    """ Clear a measurement the board may still be running from a previous attempt. Without this an
+    acquisition that was aborted, timed out or killed leaves the board busy, and every later one
+    either fails with 'Measurement is already running' or never returns. """
+    if measurement_running(self):
+        abort_measure(self)
+
     # The sensor S14290 is a high speed sensor and is not completely cleared by one read out.
     # Therefore it may not be used without a reset signal, or following readouts have a crosstalk.
     status = self.dll.DLLCloseShutter(self.drvno)

--- a/src/main.py
+++ b/src/main.py
@@ -590,10 +590,10 @@ class MainInterface(QtWidgets.QMainWindow):
     def acquire_measurement(self):
         # take one spectrum with spectrometer
         if self.measurement_busy:
-            try:
-                self.measurement.take_spectrum()
-            except AttributeError:
-                logger.info('%s Measurement not started, devices are busy'%datetime.datetime.now())
+            """ take_spectrum() runs the blocking hardware readout, and this is the GUI thread: calling
+            it here froze the whole interface for as long as the camera took to answer. Let the running
+            measurement finish instead. """
+            logger.info('%s Measurement not started, devices are busy'%datetime.datetime.now())
         else:
             self.measurement_busy = True
             self.DataHandling.clear_data()

--- a/src/main.py
+++ b/src/main.py
@@ -263,6 +263,7 @@ class MainInterface(QtWidgets.QMainWindow):
         self.CameraDisplay = CameraDisplay()
         self.AcquisitionSettings = AcquisitionSettings()
         self.AcquisitionSettings.is_busy = lambda: self.measurement_busy
+        self.AcquisitionSettings.parameter_changed = self.spectrometer_parameter_changed
 
         """ The settings panel is laid out to fit without scrolling, so it goes in directly. It is
         given the width its controls need rather than a fixed fraction: clipped labels made the first
@@ -483,6 +484,20 @@ class MainInterface(QtWidgets.QMainWindow):
             logger.info('%s Camera view connected to %s'
                         % (datetime.datetime.now(), getattr(spectrometer, 'name', spectrometer)))
 
+    def spectrometer_parameter_changed(self, parameter, value):
+        '''
+            Called by the Acquisition panel after it has set a camera parameter on the driver.
+            The tree row is read-only for the spectrometer, so nothing else would refresh it, and
+            self.parameter is what gets recorded alongside the data: both have to follow.
+            input:
+                - parameter (str): parameter name
+                - value (float): value that was applied
+        '''
+        self.parameter[parameter] = value
+        widget = self.parameter_widgets.get(parameter)
+        if widget is not None:
+            widget.setValue(value)
+
     def connect_acquisition_settings(self):
         '''
             Points the Acquisition tab at the active spectrometer. Cameras without a configurable
@@ -536,7 +551,11 @@ class MainInterface(QtWidgets.QMainWindow):
         self.parameter_widgets[param] = spin
 
         param_info = self.parameter_dic[device][param]
-        force_read_only = (device == 'cryostat')
+        """ The spectrometer joins the cryostat in being read-only here: its settings are edited in
+        the Acquisition panel of Spectrum View, beside the acquisition they affect, and this tree
+        shows them so the whole hardware state can be read at a glance. The SLM and the other devices
+        keep their editable rows. """
+        force_read_only = device in ('cryostat', 'spectrometer')
         spin.setReadOnly(param_info['read'] or force_read_only)
 
         try:

--- a/src/main.py
+++ b/src/main.py
@@ -261,6 +261,10 @@ class MainInterface(QtWidgets.QMainWindow):
         row is the spectrum. Splitters rather than a fixed grid, so the spectrum can be dragged to
         take the whole height once alignment is done. """
         self.CameraDisplay = CameraDisplay()
+        """ Changing the readout region changes the scale of the counts by the number of rows summed,
+        so a curve taken under the previous region would dominate the axes and make the new one read
+        as flat at zero. """
+        self.CameraDisplay.roi_applied.connect(self.readout_region_changed)
         self.AcquisitionSettings = AcquisitionSettings()
         self.AcquisitionSettings.is_busy = lambda: self.measurement_busy
         self.AcquisitionSettings.parameter_changed = self.spectrometer_parameter_changed
@@ -483,6 +487,18 @@ class MainInterface(QtWidgets.QMainWindow):
             self._camera_display_source = worker
             logger.info('%s Camera view connected to %s'
                         % (datetime.datetime.now(), getattr(spectrometer, 'name', spectrometer)))
+
+    def readout_region_changed(self, y0, height):
+        '''
+            Clears the spectrum plots after the camera readout region changed.
+            input:
+                - y0 (int): first sensor row now read
+                - height (int): number of rows now covered
+        '''
+        for plot in self.spectrum_plots:
+            plot.clear_plot()
+        logger.info('%s Readout region changed to rows %d-%d, spectrum plots cleared'
+                    % (datetime.datetime.now(), y0, y0 + height - 1))
 
     def spectrometer_parameter_changed(self, parameter, value):
         '''

--- a/src/main.py
+++ b/src/main.py
@@ -485,6 +485,14 @@ class MainInterface(QtWidgets.QMainWindow):
                     # Si le paramètre est du texte (ex: "Stable"), on ignore l'erreur du spinbox
                     pass
 
+        """ Record the hardware state alongside the data. The Updater only carries the read-only
+        parameters, so it is merged over the settings held here to give the full picture. Nothing
+        called DataHandling.update_parameter() before, which is why saved files carried no hardware
+        settings at all. """
+        recorded = dict(self.parameter)
+        recorded.update(new_parameter)
+        self.DataHandling.update_parameter(recorded)
+
 
     def change_parameter(self, parameter, value):
         # change parameter when called from another script

--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ from GUI.MeasurementPlot import LOmeasurementPlot, MDCSmeasurementPlot, MDCSmeas
 from GUI.LUT_Calib_plot import LUT_Calib_plot, LUT_Calib_intensity_plot
 from GUI.SLMDisplay import SLMDisplay
 from GUI.CameraDisplay import CameraDisplay
+from GUI.AcquisitionSettings import AcquisitionSettings
 from DataHandling.DataHandling import DataHandling
 from measurements.MeasurementClasses import AcquireMeasurement,RunMeasurement,BackgroundMeasurement, ViewMeasurement
 from measurements.MDCSClasses import AcquireLO, BoxcarGeometry
@@ -233,9 +234,6 @@ class MainInterface(QtWidgets.QMainWindow):
 
         # add items to GUI
         self.SpectrometerPlot = SpectrometerPlot()
-        vbox = QtWidgets.QVBoxLayout()
-        vbox.addWidget(self.SpectrometerPlot)
-        self.spectro_tab.setLayout(vbox)
         self.ParameterPlot = ParameterPlot(self.parameter_dic)
         vbox = QtWidgets.QVBoxLayout()
         vbox.addWidget(self.ParameterPlot)
@@ -257,13 +255,47 @@ class MainInterface(QtWidgets.QMainWindow):
         self.LUT_Calib_plot_2 = LUT_Calib_intensity_plot(self.LUT_calib_plot_layout_2)
         self.slm_display_plot= SLMDisplay(self.slm_display)
 
-        """ Camera view tab. Built in code rather than in main_GUI.ui: the .ui file is edited by
-        several people in Qt Designer and merges badly, so a self-contained tab avoids conflicts.
-        The view is fed straight from the camera worker and deliberately bypasses DataHandling,
-        since it shows live 2D frames for alignment rather than measurement data. """
+        """ The spectro tab is composed here rather than in main_GUI.ui: the .ui file is edited by
+        several people in Qt Designer and merges badly, so it leaves spectro_tab empty and everything
+        is assembled in code. Top row is the acquisition settings beside the live camera view, bottom
+        row is the spectrum. Splitters rather than a fixed grid, so the spectrum can be dragged to
+        take the whole height once alignment is done. """
         self.CameraDisplay = CameraDisplay()
-        self.tabWidget.addTab(self.CameraDisplay, 'Camera')
+        self.AcquisitionSettings = AcquisitionSettings()
+        self.AcquisitionSettings.is_busy = lambda: self.measurement_busy
+
+        """ The settings panel is laid out to fit without scrolling, so it goes in directly. It is
+        given the width its controls need rather than a fixed fraction: clipped labels made the first
+        version unreadable. """
+        top_splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        top_splitter.addWidget(self.AcquisitionSettings)
+        top_splitter.addWidget(self.CameraDisplay)
+        """ Equal halves rather than pixel sizes: the sizes are treated as proportions, so the split
+        holds on any screen instead of depending on the font metrics of one machine. """
+        top_splitter.setStretchFactor(0, 1)
+        top_splitter.setStretchFactor(1, 1)
+        top_splitter.setSizes([1000, 1000])
+
+        spectro_splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        spectro_splitter.addWidget(top_splitter)
+        spectro_splitter.addWidget(self.SpectrometerPlot)
+        spectro_splitter.setStretchFactor(0, 1)
+        spectro_splitter.setStretchFactor(1, 1)
+        spectro_splitter.setSizes([1000, 1000])
+
+        vbox = QtWidgets.QVBoxLayout()
+        vbox.addWidget(spectro_splitter)
+        self.spectro_tab.setLayout(vbox)
+
+        """ Second tab holding nothing but the spectrum: in the lab the plot is read from across the
+        room, where the controls only get in the way. Two plot instances fed the same data, rather
+        than moving one widget between tabs. """
+        self.SpectrometerPlotFull = SpectrometerPlot()
+        self.tabWidget.insertTab(1, self.SpectrometerPlotFull, 'Spectrum')
+        self.spectrum_plots = [self.SpectrometerPlot, self.SpectrometerPlotFull]
+
         self.connect_camera_display()
+        self.connect_acquisition_settings()
 
         """ This initializes the parameter tree. It is constructed based on the device dict,
         that includes parameter information of each device """
@@ -282,8 +314,9 @@ class MainInterface(QtWidgets.QMainWindow):
         # self.spec_length = self.devices['spectrometer'].get_num_pixel()
         self.DataHandling = DataHandling(self.parameter, self.spec_length)
         self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
-        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
-        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+        for plot in self.spectrum_plots:
+            self.DataHandling.sendSpectrum.connect(plot.set_data)
+            self.DataHandling.sendMaximum.connect(plot.update_datareader)
 
         #start Beam explorer
         self.beam_explorer = BeamExplorer(self.DataHandling.get_beams())
@@ -409,10 +442,12 @@ class MainInterface(QtWidgets.QMainWindow):
         self.DataHandling.close()
         self.DataHandling = DataHandling(self.parameter, self.spec_length)
         self.DataHandling.sendParameterarray.connect(self.ParameterPlot.set_data)
-        self.DataHandling.sendSpectrum.connect(self.SpectrometerPlot.set_data)
-        self.DataHandling.sendMaximum.connect(self.SpectrometerPlot.update_datareader)
+        for plot in self.spectrum_plots:
+            self.DataHandling.sendSpectrum.connect(plot.set_data)
+            self.DataHandling.sendMaximum.connect(plot.update_datareader)
 
         self.connect_camera_display()
+        self.connect_acquisition_settings()
 
         logger.info(
             f"Switched to spectrometer: {new_name} "
@@ -447,6 +482,20 @@ class MainInterface(QtWidgets.QMainWindow):
             self._camera_display_source = worker
             logger.info('%s Camera view connected to %s'
                         % (datetime.datetime.now(), getattr(spectrometer, 'name', spectrometer)))
+
+    def connect_acquisition_settings(self):
+        '''
+            Points the Acquisition tab at the active spectrometer. Cameras without a configurable
+            trigger leave the tab disabled, the same way the Camera tab handles sensors without a
+            configurable readout region.
+        '''
+        spectrometer = self.devices.get('spectrometer')
+        self.AcquisitionSettings.set_spectrometer(spectrometer)
+        self.AcquisitionSettings.set_monochromator(self.devices.get('Monochrom'))
+        if hasattr(spectrometer, 'set_acquisition_mode'):
+            logger.info('%s Acquisition settings connected to %s'
+                        % (datetime.datetime.now(), getattr(spectrometer, 'name', spectrometer)))
+
 
     def create_parameter_array(self):
         # initialization function to store all parameters in one array
@@ -650,7 +699,8 @@ class MainInterface(QtWidgets.QMainWindow):
             self.measurement = ViewMeasurement(self.devices, self.parameter)
             self.measurement.sendProgress.connect(self.set_progress)
             self.measurement.sendSpectrum.connect(self.DataHandling.concatenate_data)
-            self.measurement.sendClear.connect(self.SpectrometerPlot.clear_plot)
+            for plot in self.spectrum_plots:
+                self.measurement.sendClear.connect(plot.clear_plot)
             self.measurement.start()
         else:
             logger.info('%s Measurement not started, devices are busy'%datetime.datetime.now())

--- a/src/main.py
+++ b/src/main.py
@@ -549,7 +549,12 @@ class MainInterface(QtWidgets.QMainWindow):
             wave = grp.attrs['xaxis']
 
         bg = data_set
-        self.DataHandling.background = bg[-self.spec_length:]
+        """ Routed through use_background() so the length is checked against the active spectrometer
+        and the background is marked as usable. Assigning the attribute directly left has_background
+        false, and a file of the wrong length was accepted without a word. """
+        if not self.DataHandling.use_background(bg):
+            self.bg_file_indicator.setText('rejected: wrong length')
+            return wave, bg
 
         # display measured spectra filepath
         idx = bg_path.rfind('/')
@@ -636,6 +641,10 @@ class MainInterface(QtWidgets.QMainWindow):
                                                      self.filename, self.comments_edit.toPlainText())
             self.measurement.sendProgress.connect(self.set_progress)
             self.measurement.sendSpectrum.connect(self.DataHandling.concatenate_data)
+            """ Without this the measured background was only ever stored as ordinary data: nothing
+            assigned DataHandling.background except loading a file, so acquiring a background and
+            ticking the correction box subtracted an uninitialised array. """
+            self.measurement.sendSpectrum.connect(self.DataHandling.set_background)
             self.measurement.sendSave.connect(self.DataHandling.save_data)
             self.measurement.start()
         else:

--- a/src/measurements/MeasurementClasses.py
+++ b/src/measurements/MeasurementClasses.py
@@ -28,11 +28,18 @@ class AcquireMeasurement(QtCore.QThread):
 
     def run(self):
         logger.info(time.strftime('%H:%M:%S') + ' Begin single spectrum acquisition')
-        if not self.terminate:  # check whether stopping measurement is called
-            self.sendProgress.emit(50)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.take_spectrum()
-            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        try:
+            if not self.terminate:  # check whether stopping measurement is called
+                self.sendProgress.emit(50)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.take_spectrum()
+                logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Single spectrum acquisition failed')
+        finally:
+            """ Progress 100 is what releases measurement_busy in the main window. Emitting it here
+            rather than only on success means a failed or stopped measurement no longer leaves the
+            interface stuck on "devices are busy" until the software is restarted. """
             self.sendProgress.emit(100)
 
     def take_spectrum(self):
@@ -59,21 +66,25 @@ class ViewMeasurement(QtCore.QThread):
         self.terminate = False
 
     def run(self):
-        while not self.terminate:  # check whether stopping measurement is called
-            t = time.time()
-            self.sendProgress.emit(50)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.spec = np.array(self.spectrometer.get_intensities())
-            self.sendClear.emit()
-            self.sendSpectrum.emit(self.wls, self.spec)
+        try:
+            while not self.terminate:  # check whether stopping measurement is called
+                t = time.time()
+                self.sendProgress.emit(50)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.spec = np.array(self.spectrometer.get_intensities())
+                self.sendClear.emit()
+                self.sendSpectrum.emit(self.wls, self.spec)
 
-            # limit too fast acquistion for computation
-            if time.time() - t < 0.02:
-                time.sleep(0.02)
+                # limit too fast acquistion for computation
+                if time.time() - t < 0.02:
+                    time.sleep(0.02)
 
-        # Finish measurement when loop is terminated
-        logger.info(time.strftime('%H:%M:%S') + ' Finished')
-        self.sendProgress.emit(100)
+            # Finish measurement when loop is terminated
+            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Continuous view failed')
+        finally:
+            self.sendProgress.emit(100)
 
     def stop(self):
         self.terminate = True
@@ -95,21 +106,25 @@ class RunMeasurement(QtCore.QThread):
 
     def run(self):
         logger.info(time.strftime('%H:%M:%S') + ' Begin continuous acquisition')
-        while not self.terminate:  # loop runs until requested stop
-            t1 = time.time()
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.spec = np.array(self.spectrometer.get_intensities())
+        try:
+            while not self.terminate:  # loop runs until requested stop
+                t1 = time.time()
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.spec = np.array(self.spectrometer.get_intensities())
 
-            # send data
-            self.sendSpectrum.emit(self.wls, self.spec)
-            progress = 50
-            self.sendProgress.emit(progress)
+                # send data
+                self.sendSpectrum.emit(self.wls, self.spec)
+                progress = 50
+                self.sendProgress.emit(progress)
 
-            # limit too fast acquistion for computation
-            if time.time() - t1 < 0.02:
-                time.sleep(0.02)
-        logger.info(time.strftime('%H:%M:%S') + ' Finished')
-        self.sendProgress.emit(100)
+                # limit too fast acquistion for computation
+                if time.time() - t1 < 0.02:
+                    time.sleep(0.02)
+            logger.info(time.strftime('%H:%M:%S') + ' Finished')
+        except Exception:
+            logger.exception('Continuous acquisition failed')
+        finally:
+            self.sendProgress.emit(100)
         return
 
     #  initiate controlled stop by enableing terminate statement, that is frequently queried in run code
@@ -136,23 +151,27 @@ class BackgroundMeasurement(QtCore.QThread):
         self.terminate = False
 
     def run(self):
-        if not self.terminate:  # check whether stopping measurement is called
-            """ Wavelengths are read once, before the loop. They used to be assigned only inside it,
-            so a background of a single scan emitted an empty array and broke the receiving slot.
-            scans is clamped because its spin box declares no minimum and so allows 0, which also
-            divided by zero below. """
-            scans = max(int(self.scans), 1)
-            self.wls = np.array(self.spectrometer.get_wavelength())
-            self.summedspec = np.array(self.spectrometer.get_intensities())
-            for i in range(scans - 1):
-                self.sendProgress.emit((i + 1) / scans * 100)
-                self.spec = np.array(self.spectrometer.get_intensities())
-                self.summedspec = self.summedspec + self.spec
-            self.spec = self.summedspec / scans
-            self.sendSpectrum.emit(self.wls, self.spec)
-            self.sendSave.emit(self.filename, self.comments)
+        try:
+            if not self.terminate:  # check whether stopping measurement is called
+                """ Wavelengths are read once, before the loop. They used to be assigned only inside
+                it, so a background of a single scan emitted an empty array and broke the receiving
+                slot. scans is clamped because its spin box declares no minimum and so allows 0,
+                which also divided by zero below. """
+                scans = max(int(self.scans), 1)
+                self.wls = np.array(self.spectrometer.get_wavelength())
+                self.summedspec = np.array(self.spectrometer.get_intensities())
+                for i in range(scans - 1):
+                    self.sendProgress.emit((i + 1) / scans * 100)
+                    self.spec = np.array(self.spectrometer.get_intensities())
+                    self.summedspec = self.summedspec + self.spec
+                self.spec = self.summedspec / scans
+                self.sendSpectrum.emit(self.wls, self.spec)
+                self.sendSave.emit(self.filename, self.comments)
+                logger.info(time.strftime('%H:%M:%S') + 'Background acquired')
+        except Exception:
+            logger.exception('Background acquisition failed')
+        finally:
             self.sendProgress.emit(100)
-            logger.info(time.strftime('%H:%M:%S') + 'Background acquired')
 
     def stop(self):
         self.terminate = True

--- a/src/measurements/MeasurementClasses.py
+++ b/src/measurements/MeasurementClasses.py
@@ -137,13 +137,18 @@ class BackgroundMeasurement(QtCore.QThread):
 
     def run(self):
         if not self.terminate:  # check whether stopping measurement is called
+            """ Wavelengths are read once, before the loop. They used to be assigned only inside it,
+            so a background of a single scan emitted an empty array and broke the receiving slot.
+            scans is clamped because its spin box declares no minimum and so allows 0, which also
+            divided by zero below. """
+            scans = max(int(self.scans), 1)
+            self.wls = np.array(self.spectrometer.get_wavelength())
             self.summedspec = np.array(self.spectrometer.get_intensities())
-            for i in range(self.scans - 1):
-                self.sendProgress.emit((i + 1) / self.scans * 100)
-                self.wls = np.array(self.spectrometer.get_wavelength())
+            for i in range(scans - 1):
+                self.sendProgress.emit((i + 1) / scans * 100)
                 self.spec = np.array(self.spectrometer.get_intensities())
                 self.summedspec = self.summedspec + self.spec
-            self.spec = self.summedspec / self.scans
+            self.spec = self.summedspec / scans
             self.sendSpectrum.emit(self.wls, self.spec)
             self.sendSave.emit(self.filename, self.comments)
             self.sendProgress.emit(100)


### PR DESCRIPTION
## Summary
Builds on fix/pixis-vertical-binning. Adds the AcquisitionSettings panel (replaces raw sti/bti spin boxes with 3 real usage modes: internal timer, laser-synced, chopper-gated) and reorganises Spectrum View around it. Moves camera parameters out of the shared hardware tree into this panel. Fixes a non-thread-safe Pixis control path (crash if a region is applied during a live measurement), an unbounded frame wait, and a plot that didn't clear between full-frame/binned modes (scales ~250x apart).

Note: also merges in fix/stresing-acquisition-reliability, since AcquisitionSettings.py needs the trigger-mode constants added there — this dependency wasn't obvious until the offscreen smoke test caught an ImportError.

## Test plan
- Offscreen smoke test passes: Camera tab + AcquisitionSettings panel both present and wired.