### PR TITLE
Fix integration time continuous streising mode

### DIFF
--- a/dependencies/environment.yml
+++ b/dependencies/environment.yml
@@ -14,3 +14,8 @@ dependencies:
   - h5py
   - scipy
   - seabreeze
+  - pyvisa
+  - opencv
+  - pip:
+    - pylablib
+    - screeninfo

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -1,6 +1,6 @@
 pyqtgraph
 numpy
-PyQt
+PyQt5
 matplotlib
 pip
 pillow
@@ -11,5 +11,5 @@ scipy
 seabreeze
 pyvisa
 pylablib
-OpenCV
+opencv-python
 screeninfo

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -34,6 +34,15 @@ TRIGGER_INPUTS = {'I': 0, 'S1': 1, 'S2': 2, 'I gated by S2': 3}
 TRIGGER_TIMER = 4
 CHOPPER_INPUTS = {'S1': 5, 'S2': 6, 'S1 and S2': 7}
 
+""" What starts the integrator that actually gates the sensor's light exposure -- a separate
+register from sti_mode/bti_mode, which only pick what starts a *readout*. XCK ties the integrator
+to the sensor's own start signal, so exposure follows the readout period (stime) with nothing
+external needed: this is what CONTINUOUS mode needs. EXTTRIG waits for a dedicated 'Ext. Trig.'
+input on the camera control box, letting the integrator be gated by an incoming pulse (delayed by
+sec_in_10ns) independently of the sensor -- this is what pulsed/EXTERNAL acquisition needs. """
+XCK = 0
+EXTTRIG = 1
+
 CONTINUOUS = 'continuous'
 EXTERNAL = 'external'
 CHOPPER = 'chopper'
@@ -97,6 +106,10 @@ class StresingCamera(QtCore.QThread):
         self.sti = int(config.get("Board0","sti"))
         self.btimer = int(float(config.get("Board0","btimer")))
         self.stimer = int(config.get("Board0","stimer"))
+        """ Delay between the pulse trigger and the start of the integrator (sec_in_10ns), used to
+        line up exposure with a laser pulse in EXTERNAL/CHOPPER mode. In CONTINUOUS mode the
+        integrator is tied to XCK instead (see set_acquisition_mode), so this has no effect there. """
+        self.pulse_sync_delay_10ns = int(config.get("Board0","shutterSecIn10ns", fallback=0))
         self.new_spectrum = False
 
         """ Deadline used when the board is waiting on an external signal. Without it a trigger that
@@ -185,6 +198,11 @@ class StresingCamera(QtCore.QThread):
         self.parameter_display_dict['Scan_Timer']['unit'] = ' '
         self.parameter_display_dict['Scan_Timer']['max'] = 1000000
         self.parameter_display_dict['Scan_Timer']['read'] = False
+
+        self.parameter_display_dict['Pulse_Sync_Delay']['val'] = self.pulse_sync_delay_10ns
+        self.parameter_display_dict['Pulse_Sync_Delay']['unit'] = ' (x10ns)'
+        self.parameter_display_dict['Pulse_Sync_Delay']['max'] = 1000000
+        self.parameter_display_dict['Pulse_Sync_Delay']['read'] = False
         # set up parameter dict that only contains value. (faster to access)
         self.parameter_dict = {}
         for key in self.parameter_display_dict.keys():
@@ -263,6 +281,10 @@ class StresingCamera(QtCore.QThread):
         elif parameter == 'Scan_Timer':
             self.driver.settings.camera_settings[self.driver.drvno].stime_in_microsec = int(value)
             self.stimer = value
+            self.new_spectrum = False
+        elif parameter == 'Pulse_Sync_Delay':
+            self.driver.settings.camera_settings[self.driver.drvno].sec_in_10ns = int(value)
+            self.pulse_sync_delay_10ns = value
             self.new_spectrum = False
         init_measure(self) # type: ignore
 
@@ -383,6 +405,15 @@ class StresingCamera(QtCore.QThread):
         cam = self.driver.settings.camera_settings[self.driver.drvno]
         cam.sti_mode, cam.bti_mode = sti, bti
         self.sti, self.bti = sti, bti
+
+        """ sti_mode/bti_mode only pick what starts a *readout*. The integrator that actually gates
+        the sensor's exposure is a separate register (trigger_mode_integrator) and was left at
+        whatever the ini configured (exttrig, for pulsed operation) no matter which mode was chosen
+        here -- so CONTINUOUS changed the readout cadence while the integrator kept waiting on an
+        external pulse that never came, and exposure stopped tracking Scan_Timer entirely. Tie it to
+        XCK in CONTINUOUS so exposure follows the sensor's own readout timing; keep EXTTRIG for
+        EXTERNAL/CHOPPER, where sec_in_10ns delays the integrator to line up with the incoming pulse. """
+        cam.trigger_mode_integrator = XCK if mode == CONTINUOUS else EXTTRIG
 
         """ The board only reads a timer in the mode that uses it. Writing them in the other modes
         would leave values on screen that have no effect, which is what made the old parameter table

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -497,6 +497,14 @@ class StresingCamera(QtCore.QThread):
         self.spectrum = measure(self, True, timeout_s) # type: ignore
         self.new_spectrum = True
 
+    def close_driver(self):
+        """
+            Releases the PCIe board and its DMA buffer (DLLExitDriver). Without this the board stays
+            reserved after the app closes, and the next DLLInitMeasurement() inherits a DMA state the
+            previous session never released.
+        """
+        exit(self) # type: ignore
+
 class StresingWorker(QtCore.QThread):
     """ Publishes the spectra acquired from the Stresing camera to the interface.
     The camera is read synchronously by StresingCamera.acquire_spectrum() in the thread that asks for

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -103,12 +103,11 @@ def init_driver(self, path_dll, config):
     self.settings.camera_settings[self.drvno].use_software_polling = int(config.get("board0","useSoftwarePolling")) # Determines which method is used to copy data from DMA to user buffer.
     self.settings.camera_settings[self.drvno].adc_gain = int(config.get("board0","adcGain")) # Controlling the gain function of the ADC in 3030 high speed cameras (sensor S14290 use 5 or 6).
     self.settings.camera_settings[self.drvno].tor = int(config.get("board0","tor")) # Shows the exposure window at the O output of the PCI card.
-    self.settings.camera_settings[self.drvno].trigger_mode_integrator = int(config.get("board0","triggerCc")) # Trigger mode camera control.
     self.settings.camera_settings[self.drvno].sec_in_10ns = int(config.get("board0","shutterSecIn10ns", fallback=0)) # Scan exposure control: delay, in units of 10 ns, between the pulse trigger and the start of the integrator. Only takes effect when trigger_mode_integrator is exttrig (pulsed/external acquisition); in continuous mode the integrator is tied to XCK and this is unused.
 
     # Scan trigger input (sti) mode determines the signal on which one readout is started :
-    #   0 - External trigger on input I of PCIe board 
-    #   1 - External trigger on input S1 of PCIe board 
+    #   0 - External trigger on input I of PCIe board
+    #   1 - External trigger on input S1 of PCIe board
     #   2 - External trigger on input S2 of PCIe board
     #   3 - External trigger by I but only when enabled by S2.
     #   4 - Trigger with internal timer. Select the time between two readouts with stime.
@@ -116,6 +115,18 @@ def init_driver(self, path_dll, config):
     self.settings.camera_settings[self.drvno].sti_mode = int(config.get("board0","sti"))
     if self.settings.camera_settings[self.drvno].sti_mode == 4:
         self.settings.camera_settings[self.drvno].stime_in_microsec = int(config.get("board0","stimer"))
+
+    """ trigger_mode_integrator (triggerCc in the ini) only gets set to XCK for continuous mode inside
+    Stresing.set_acquisition_mode() -- which runs only when the operator opens Acquisition Settings and
+    clicks Apply. Since sti/bti already read 4 (continuous, internal timer) straight from the ini, the
+    panel shows "Continuous" as already active and gives no reason to click Apply, so the board started
+    with the readout cadence continuous but the integrator still parked on triggerCc's raw ini value
+    (exttrig on config_UdeM.ini) waiting for a pulse that never comes -- exposure never tracked Scan_Timer
+    at all until Apply was pressed by hand. Deriving it here from sti_mode keeps it correct from boot,
+    matching the mapping in Stresing.py's XCK/EXTTRIG constants (XCK=0, EXTTRIG=1). """
+    self.settings.camera_settings[self.drvno].trigger_mode_integrator = (
+        0 if self.settings.camera_settings[self.drvno].sti_mode == 4
+        else int(config.get("board0","triggerCc")))
 
     # Block trigger input (bti) mode determines the signal on which one block of readouts is started :
     #   0 - External trigger on input I of PCIe board

--- a/src/drivers/StresingDriver.py
+++ b/src/drivers/StresingDriver.py
@@ -104,6 +104,7 @@ def init_driver(self, path_dll, config):
     self.settings.camera_settings[self.drvno].adc_gain = int(config.get("board0","adcGain")) # Controlling the gain function of the ADC in 3030 high speed cameras (sensor S14290 use 5 or 6).
     self.settings.camera_settings[self.drvno].tor = int(config.get("board0","tor")) # Shows the exposure window at the O output of the PCI card.
     self.settings.camera_settings[self.drvno].trigger_mode_integrator = int(config.get("board0","triggerCc")) # Trigger mode camera control.
+    self.settings.camera_settings[self.drvno].sec_in_10ns = int(config.get("board0","shutterSecIn10ns", fallback=0)) # Scan exposure control: delay, in units of 10 ns, between the pulse trigger and the start of the integrator. Only takes effect when trigger_mode_integrator is exttrig (pulsed/external acquisition); in continuous mode the integrator is tied to XCK and this is unused.
 
     # Scan trigger input (sti) mode determines the signal on which one readout is started :
     #   0 - External trigger on input I of PCIe board 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """
 Created on Tue Jan  1 14:34:11 2025
+@Simon Daneau
+@Felix Thouin
+@Mathieu Desmarais
+@Kathie Khosh
 @author: David Tiede
 """
 

--- a/src/main.py
+++ b/src/main.py
@@ -1390,6 +1390,16 @@ class MainInterface(QtWidgets.QMainWindow):
         '''
             Closes all windows when the main window is closed.
         '''
+        """ The Stresing PCIe board's DMA buffer is only released by DLLExitDriver(). Without this the
+        board stays reserved after the app closes, and the next DLLInitMeasurement() has to clean up a
+        DMA state the previous session never released -- which fails outright on ESLSCDLL < 4.18.4 and
+        has been seen to require a full reboot to clear. """
+        for spectrometer in getattr(self, 'spectrometers', {}).values():
+            if hasattr(spectrometer, 'close_driver'):
+                try:
+                    spectrometer.close_driver()
+                except Exception as e:
+                    logger.warning('Could not cleanly release the Stresing board: %s', e)
         QApplication.closeAllWindows()
 
     def save_calibration(self, filename_prefix="Filename", use_prompt=True, save_dir=None):


### PR DESCRIPTION
## integration time

Correction of the first pull request. 

First, the code was working in the form it was, but the sequence was a bit not clear or tricky. 

Now, trigger_mode_integrator is derivated from sti_mode from the initalisaton. It make that the good trigger_mode_value (for continuum) is set when the program open in continuous mode by default. 

##DMA buffer error
There is also a commit to try to fix the DMA buffer error. The fix will solve the problem  if it come from closing the program, but all bug in using will not solve anything. 

Turn out, the bug is documented on github https://github.com/Entwicklungsburo-Stresing/EBST_CAM.

- The changelog du SDK show a fix in the version 4.18.8 "Fix crash at CleanDMa called by DLLExitDriver() and DLLInitMeasurement()

- We are on 4.17.8.

wanted to change it direction, but the problem is from 4.18.3, ESLSCDLL depend of a new library lscpciej.dll and not wdapi1400.dll. 

Claude can do it, but he say it will be safer and easier to wait for the complete installation from streising compagnie. 


## update of the requirements. 

doing my env for this computer, I saw that some package was not in the requirements, so I update it. 




