### PR TITLE
Integrate Wake Forest development changes (Katie), reapplied cleanly

### DIFF
--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -1,6 +1,6 @@
 pyqtgraph
 numpy
-PyQt
+PyQt5
 matplotlib
 pip
 pillow
@@ -11,5 +11,6 @@ scipy
 seabreeze
 pyvisa
 pylablib
-OpenCV
+opencv-python
 screeninfo
+pylablib

--- a/src/drivers/Instruments.py
+++ b/src/drivers/Instruments.py
@@ -13,6 +13,7 @@ from drivers.Optidry250 import CryoPasqal
 from drivers.Pixis import Pixis
 from drivers.SpectraPro2300i import SpectraPro2300i
 from drivers.SpectraPro2300iDemo import SpectraPro2300iDemo
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -20,18 +21,9 @@ def load_instruments():
     """
         Loads the connected instruments into a device dictionnary
     """
-
     # set devices dict
     devices=defaultdict(dict)
-
     # initialize cryostat
-    """ This is a demo devices that has read and write parameters. 
-    Illustrates use of parameters"""
-    # always try to include communication on important events.
-    # This is extremely useful for debugging and troubleshooting.
-    logger.warning('%s You are using a DEMO version of the cryostat'%datetime.datetime.now())
-    
-
     try: 
         cryostat = CryoPasqal() # launch cryostat interface
         devices['cryostat'] = cryostat # store in global device dict.
@@ -42,15 +34,11 @@ def load_instruments():
         logger.error('%s Pascal Cryostat initialization failed at interface startup. Error type %s' % (datetime.datetime.now(),str(e)))
         logger.info('%s CryoDemo connected' % datetime.datetime.now())
 
-
-
-
-
-
     # initialize SLM
     try:
-        #raise Exception('DEMO')
-        SLM = Slm()
+        # path_config = Path(r"C:\Program Files\Meadowlark Optics\Blink 1920 HDMI\config_UdeM.ini")
+        path_config = (r"C:\Program Files\Meadowlark Optics\Blink 1920 HDMI\config_WFU.ini")
+        SLM = Slm(path_config)
         devices['SLM'] = SLM
         logger.info('%s SLM connected' % datetime.datetime.now())
     except Exception as e:
@@ -59,54 +47,93 @@ def load_instruments():
         logger.error('%s SLM initialization failed at interface startup. Error type %s' % (datetime.datetime.now(),str(e)))
         logger.info('%s SLMDemo connected' % datetime.datetime.now())
 
-    # initialize MonochromDemo
-    grating_params_stresing={
-        'focal_length_mm':300,
-        'f':np.float64(305381928.6149399),
-        'delta':np.float64(0.11432112488955509),
-        'gamma':np.float64(0.5337955112241486),
-        'n0':np.float64(539.4), # Central pixel
-        'offset_adjust':0,
-        'd_grating':833.3333333333334,
-        'x_pixel':24000.0,
-        'curvature':np.float64(5.736575254871788e-07),
-    }
-    f, delta, gamma, n0, offset_adjust, d_grating, x_pixel, curvature = [np.float64(330605663.74965495), np.float64(-0.20488367116307532), np.float64(2.021864300924973), np.float64(508.0), 0, 6666.666666666667, 26000.0, np.float64(3.1224154313329654e-06)]
-    grating_params_pixis = {
-        'focal_length_mm':300,
-        'f':np.float64(300000000.0),
-        'delta':np.float64(0.06),
-        'gamma':np.float64(0.5),
-        'n0':np.float64(516.6), # Central pixel
-        'offset_adjust':0,
-        'd_grating':833.3333333333334,
-        'x_pixel':26000,
-        'curvature':np.float64(0.0),
-    }
+    # initialize Stresing & Monochrom
+    spectrometers = {}
 
-    grating_params = {
-        'Stresing': grating_params_stresing,
-        'Pixis': grating_params_pixis
-    }
     try:
-        Monochrom = SpectraPro2300i(grating_params)
-        logger.info('%s SpectraPro2300i connected' % datetime.datetime.now())
+        # Path to the configuration folder
+        folder_path_config = Path(r"C:\Program Files\Stresing\Escam")
+
+        # Choose the configuration file
+        config_name = "config_UdeM.ini"
+        config_name = "config.ini" # WFU path
+
+        # Full path to the configuration file
+        path_config = folder_path_config / config_name
+        path_config = str(path_config)
+
+        if config_name == "config_UdeM.ini":
+            print('Udem Settings Chosen')
+            stresing_params = {
+                'pixel_size_mm': 24e-3,
+                'num_pixels': 1010,
+                'calibrated': False,
+                'calibrationThirdOrder': -3e-5,
+                'calibrationSlope': 0.9891,
+                'calibrationOffset': -51.163
+            }
+
+            grating_params_pixis = {
+                    'focal_length_mm':300,
+                    'f':np.float64(300000000.0),
+                    'delta':np.float64(0.06),
+                    'gamma':np.float64(0.5),
+                    'n0':np.float64(516.6), # Central pixel
+                    'offset_adjust':0,
+                    'd_grating':833.3333333333334,
+                    'x_pixel':26000,
+                    'curvature':np.float64(0.0),
+                }
+
+            grating_params = {
+                'Stresing': stresing_params,
+                'Pixis': grating_params_pixis
+            }
+
+            try:
+                Monochrom = SpectraPro2300i(grating_params)
+                logger.info('%s SpectraPro2300i connected' % datetime.datetime.now())
+            except Exception as e:
+                Monochrom = SpectraPro2300iDemo(grating_params)
+                logger.error('%s SpectraPro2300i initialization failed at interface startup. Error type %s' % (datetime.datetime.now(),str(e)))
+                logger.info('%s SpectraPro2300iDemo connected' % datetime.datetime.now())
+
+
+        else:
+            print('WFU Settings Chosen')
+            stresing_params = {
+                'pixel_size_mm': 24e-3,
+                'num_pixels': 1010,
+                'calibrated': False,
+                'calibrationThirdOrder': -1.29565e-07,
+                'calibrationSecondOrder': 0.000165366,
+                'calibrationFirstOrder': 0.409445,
+                'calibrationOffset': 265.515,
+            }
+
+            grating_params = {
+                'focal_length_mm': 150,  # should be 150
+                'f': np.float64(330000000.08),
+                'delta': np.float64(-0.7775441817634736),
+                'gamma': np.float64(0.7313712629429233),
+                'n0': np.float64(511.0),
+                'offset_adjust': 0.0,
+                'd_grating': np.float64(3333.3333333333335),
+                'x_pixel': 24000.0,
+                'curvature': np.float64(-9.999764504749403e-07),
+            }
+
+            Monochrom = Shamrock(grating_params)
+            devices['Monochrom'] = Monochrom
+            logger.info('%s Monochrom DEMO connected' % datetime.datetime.now())
+
+        camera= StresingCamera(stresing_params, path_config)
+        camera.attach_to_monochromator(Monochrom)
+        spectrometers['Stresing'] = camera
+        logger.info('%s Stresing connected' % datetime.datetime.now())
     except Exception as e:
-        Monochrom = SpectraPro2300iDemo(grating_params)
-        logger.error('%s SpectraPro2300i initialization failed at interface startup. Error type %s' % (datetime.datetime.now(),str(e)))
-        logger.info('%s SpectraPro2300iDemo connected' % datetime.datetime.now())
+        logger.warning(f'Stresing failed: {e}')
 
-    devices['Monochrom'] = Monochrom
-
-    # initialize Cameras
-    stresing_params={
-        'pixel_size_mm':24e-3,
-        'num_pixels':1010,
-        'calibrated': True,
-        'calibrationThirdOrder': -3e-5,
-        'calibrationSlope': 0.9891,
-        'calibrationOffset': -51.163
-    }
     pixis_params = {
         'pixel_size_mm':26e-3,
         'num_pixels':1024,
@@ -115,16 +142,6 @@ def load_instruments():
         'calibrationSlope':0,
         'calibrationOffset':0
     }
-
-    spectrometers = {}
-    
-    try:
-        camera= StresingCamera(stresing_params)
-        camera.attach_to_monochromator(Monochrom)
-        spectrometers['Stresing'] = camera
-        logger.info('%s Stresing connected' % datetime.datetime.now())
-    except Exception as e:
-        logger.warning(f'Stresing failed: {e}')
 
     try:
         camera = Pixis(pixis_params)

--- a/src/drivers/SLM.py
+++ b/src/drivers/SLM.py
@@ -37,9 +37,9 @@ class Slm(QtCore.QThread):
     name = 'SLM_Meadowlark'
     type= 'SLM'
 
-    def __init__(self):
+    def __init__(self, path_config):
         super(Slm, self).__init__()
-        self.slm_worker= SLMWorker()
+        self.slm_worker= SLMWorker(path_config)
         self.slm_worker.slmParamsSignal.connect(self.handle_slm_params)
         self.slm_worker.slmParamsTemperature.connect(self.handle_slm_temperature)
         self.slm_worker.sendFlag.connect(self.set_phaseShown)
@@ -199,11 +199,9 @@ class SLMWorker(QtCore.QThread):
     imageSLM = QtCore.pyqtSignal(np.ndarray)
     sendFlag = QtCore.pyqtSignal(bool)
     
-    def __init__(self):
+    def __init__(self, path_config):
+
         super(SLMWorker, self).__init__() # Elevates this thread to be independent.
-
-        path_config = Path(r"C:\Program Files\Meadowlark Optics\Blink 1920 HDMI\config_UdeM.ini")
-
         # Create a ConfigParser object
         config = CaseInsensitiveConfig()
         # Read the INI file

--- a/src/drivers/Shamrock.py
+++ b/src/drivers/Shamrock.py
@@ -60,7 +60,7 @@ class Shamrock(QtCore.QThread):
             self.parameter_dict['grating'] = value
             self.grating = value
 
-    def get_hardware_parameters(self):
+    def get_hardware_parameters(self, hardware_params):
         """
             Returns the hardware parameters of the monochromator
             output:

--- a/src/drivers/Stresing.py
+++ b/src/drivers/Stresing.py
@@ -43,7 +43,7 @@ class StresingCamera(QtCore.QThread):
 
     name = 'StresingCamera'
 
-    def __init__(self,hardware_params):
+    def __init__(self,hardware_params, path_config):
         super(StresingCamera, self).__init__()
 
         # initialize Worker
@@ -67,13 +67,14 @@ class StresingCamera(QtCore.QThread):
         path_dll = folder_path_dll / "stresing" / "ESLSCDLL.dll"
         path_dll = str(path_dll)
 
-        path_config = Path(r"C:\Program Files\Stresing\Escam\config_UdeM.ini")
-        #path_config = Path(r"C:\Program Files\Stresing\Escam\config.ini") # WFU path
-
         # Create a ConfigParser object
         config = CaseInsensitiveConfig()
         # Read the INI file
         config.read(path_config)
+
+        print(path_config)
+        print("Reading:", path_config)
+        print("Sections:", config.sections())
 
         # Intitalize stresing camera 
         self.driver = init_driver(self, path_dll, config) # type: ignore
@@ -304,26 +305,37 @@ class StresingCamera(QtCore.QThread):
                 self.wavelengths = ((d_grating / m_order) * (np.sin(psi - 0.5 * gamma) + np.sin(psi + 0.5 * gamma + eta))) + curvature * n ** 2
 
             else:
-
-                pixel_size_mm = 24 / 1E3  # specs of Stresing
-                focal_length_mm = 300  # specs of SP2300i
-                num_pixels = 1010  # specs of Stresing
-
                 # Calculate linear dispersion (nm/mm)
-                dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
+                # dispersion = 1e6 / (focal_length_mm * self.grating_lines_per_mm)
+                #
+                # # Center pixel
+                # center_pixel = num_pixels // 2
+                #
+                # # Pixel index array
+                # pixel_indices = np.arange(num_pixels)
+                #
+                # # Wavelength at each pixel
+                # self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
+                # # Refine the calibration using a mercury spectral lamp
+                # self.wavelengths = self.hardware_params['calibrationThirdOrder']*self.wavelengths**2 + self.hardware_params['calibrationSlope']*self.wavelengths + self.hardware_params['calibrationOffset']
 
-                # Center pixel
-                center_pixel = num_pixels // 2
+                if self.center_wavelength == 500:
+                    # print('center wavelength = 500')
+                    self.wavelengths = np.arange(num_pixels)
+                if self.center_wavelength > 500:
+                    # print('center wavelength > 500')
+                    self.wavelengths = np.arange(num_pixels) + (self.center_wavelength - 500)
+                if self.center_wavelength < 500:
+                    # print('center wavelength < 500')
+                    self.wavelengths = np.arange(num_pixels) + (self.center_wavelength - 500)
 
-                # Pixel index array
-                pixel_indices = np.arange(num_pixels)
-
-                # Wavelength at each pixel
-                self.wavelengths = self.center_wavelength + (pixel_indices - center_pixel) * dispersion * pixel_size_mm
-
+                self.wavelengths = self.hardware_params['calibrationThirdOrder'] * (self.wavelengths ** 3) + \
+                                   self.hardware_params['calibrationSecondOrder'] * (self.wavelengths ** 2) + \
+                                   self.hardware_params['calibrationFirstOrder'] * (self.wavelengths) + \
+                                   self.hardware_params['calibrationOffset']
         else:
-            self.wavelengths= self.hardware_params['num_pixels']
-            logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength'%datetime.datetime.now())
+            self.wavelengths = self.hardware_params['num_pixels']
+            logger.warning('%s No grating found attached to Stresing. Returning pixels indices instead of wavelength' % datetime.datetime.now())
 
     def attach_to_monochromator(self,monochromator):
         """

--- a/src/drivers/slm/config_WFU.ini
+++ b/src/drivers/slm/config_WFU.ini
@@ -1,0 +1,12 @@
+[SLM0]
+driverName = Slm_Meadowlark_optics
+cWrapper = C:\\Program Files\\Meadowlark Optics\\Blink 1920 HDMI\\SDK\\Blink_C_wrapper.dll
+imageGen = C:\\Program Files\\Meadowlark Optics\\Blink 1920 HDMI\\SDK\\ImageGen.dll
+lutFile = C:\Program Files\Meadowlark Optics\Blink 1920 HDMI\LUT Files\19x12_8bit_linearVoltage.lut
+
+rgb = 1
+isEightBitImage = 1
+height = 1200
+width = 1920
+depth = 8
+bytesPerPixel = 4


### PR DESCRIPTION
Katie's Katie_integrate_dev_at_Wake branch carried its real changes as CRLF commits, which made every file in the diff look 100% rewritten against dev's LF content (~30,800 lines across 199 files) -- unreviewable, and her latest update (merging dev into her branch rather than rebasing onto our new line-ending fix) would have reverted the .gitattributes normalization if merged as-is.

Reapplied her actual changes here instead, taken directly from her branch and normalized to LF, on top of current dev (verified dev hasn't touched any of these files since her merge-base, so this is exactly her work, nothing reconciled or reinterpreted):
- src/drivers/slm/config_WFU.ini (new): SLM config for the Wake Forest panel -- 8-bit (Slm_Meadowlark_optics driver, depth=8), not 10-bit like UdeM's.
- SLM.py / Stresing.py: constructors take an explicit path_config argument instead of it being hardcoded inside the driver.
- Instruments.py: site selection (UdeM vs WFU) for the Stresing config path, monochromator (Shamrock for WFU instead of SpectraPro2300i), and grating/ calibration constants for Wake Forest's setup.
- Shamrock.py: get_hardware_parameters() signature fix.
- requirements.txt: PyQt -> PyQt5, OpenCV -> opencv-python (actual PyPI package names).

Left as-is, not mine to silently rewrite: Instruments.py currently selects UdeM vs WFU by two consecutive assignments to config_name (the second one always wins) -- same hardcoded-selection pattern the config consolidation plan discussed replacing, just moved here from Stresing.py. A few debug print() calls also carried over. Worth a follow-up once the config_loader plan is implemented, not blocking this integration.

#### Notes from Katie ### 

Thank you to Mathieu for helping me solve the GitHub issue mentioned above, so that you can actually see the real changes I made.  

We discussed in the meeting that for now, having one script (Instruments.py) to select the hard-coded config file would be okay for now. Previously, there were multiple locations deep inside the Stresing and SLM drivers. If we want to improve this further, I can. 

The beam explorer fix that was merged into dev this week is also working for our system at Wake Forest. Additionally, I am no longer having the bug I mentioned in the meeting on Tuesday for pulse compression. 